### PR TITLE
BIFROST-7845 - Add test loading all compounds

### DIFF
--- a/test/compounds/integration/load_all_compounds_test00.json
+++ b/test/compounds/integration/load_all_compounds_test00.json
@@ -1,0 +1,4256 @@
+{
+    "header": {
+        "metadata": [
+            {
+                "metaName": "adskFileFormatVersion",
+                "metaValue": "100L"
+            }
+        ]
+    },
+    "namespaces": [],
+    "types": [],
+    "compounds": [
+        {
+            "name": "USD::Test::Integration::load_all_compounds_test00",
+            "uriImported": "file:///load_all_compounds_test00.json",
+            "metadata": [
+                {
+                    "metaName": "io_nodes",
+                    "metadata": [
+                        {
+                            "metaName": "io_inodes",
+                            "metadata": [
+                                {
+                                    "metaName": "input",
+                                    "metadata": [
+                                        {
+                                            "metaName": "DisplayMode",
+                                            "metaType": "string",
+                                            "metaValue": "2"
+                                        },
+                                        {
+                                            "metaName": "LayoutPos",
+                                            "metaType": "string",
+                                            "metaValue": "-885 -61"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "metaName": "io_onodes",
+                            "metadata": [
+                                {
+                                    "metaName": "output",
+                                    "metadata": [
+                                        {
+                                            "metaName": "DisplayMode",
+                                            "metaType": "string",
+                                            "metaValue": "2"
+                                        },
+                                        {
+                                            "metaName": "LayoutPos",
+                                            "metaType": "string",
+                                            "metaValue": "862 389"
+                                        },
+                                        {
+                                            "metaName": "io_ports",
+                                            "metadata": [
+                                                {
+                                                    "metaName": "test_info"
+                                                },
+                                                {
+                                                    "metaName": "failure_msgs"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "metaName": "_recentNode_",
+                    "metaType": "string",
+                    "metaValue": "BifrostGraph,USD::IO,read_usd_curves"
+                },
+                {
+                    "metaName": "_recentNode_",
+                    "metaType": "string",
+                    "metaValue": "BifrostGraph,USD::Utils,create_child_prim_path"
+                },
+                {
+                    "metaName": "_recentNode_",
+                    "metaType": "string",
+                    "metaValue": "BifrostGraph,USD::VariantSet,add_variant"
+                },
+                {
+                    "metaName": "_recentNode_",
+                    "metaType": "string",
+                    "metaValue": "BifrostGraph,USD::Stage,create_usd_stage"
+                },
+                {
+                    "metaName": "_recentNode_",
+                    "metaType": "string",
+                    "metaValue": "BifrostGraph,USD::Stage,add_to_stage"
+                },
+                {
+                    "metaName": "ViewportRect",
+                    "metaType": "string",
+                    "metaValue": "-989.709 -100.667 2422.75 1422.67"
+                },
+                {
+                    "metaName": "DisplayMode",
+                    "metaType": "string",
+                    "metaValue": "2"
+                },
+                {
+                    "metaName": "LayoutPos",
+                    "metaType": "string",
+                    "metaValue": "-993.076 212.985"
+                }
+            ],
+            "ports": [
+                {
+                    "portName": "test_info",
+                    "portDirection": "output",
+                    "portType": "string"
+                },
+                {
+                    "portName": "failure_msgs",
+                    "portDirection": "output",
+                    "portType": "array<string>"
+                }
+            ],
+            "compounds": [
+                {
+                    "name": "attribute_compounds_and_nodedefs",
+                    "uriImported": "file:///load_all_compounds_test00.json",
+                    "metadata": [
+                        {
+                            "metaName": "io_nodes",
+                            "metadata": [
+                                {
+                                    "metaName": "io_inodes",
+                                    "metadata": [
+                                        {
+                                            "metaName": "input",
+                                            "metadata": [
+                                                {
+                                                    "metaName": "DisplayMode",
+                                                    "metaType": "string",
+                                                    "metaValue": "2"
+                                                },
+                                                {
+                                                    "metaName": "LayoutPos",
+                                                    "metaType": "string",
+                                                    "metaValue": "159 518"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "metaName": "io_onodes",
+                                    "metadata": [
+                                        {
+                                            "metaName": "output",
+                                            "metadata": [
+                                                {
+                                                    "metaName": "DisplayMode",
+                                                    "metaType": "string",
+                                                    "metaValue": "2"
+                                                },
+                                                {
+                                                    "metaName": "LayoutPos",
+                                                    "metaType": "string",
+                                                    "metaValue": "399 518"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "metaName": "ViewportRect",
+                            "metaType": "string",
+                            "metaValue": "75.3333 391.283 2275.33 1336.1"
+                        }
+                    ],
+                    "ports": [],
+                    "compoundNodes": [
+                        {
+                            "nodeName": "add_attribute_connection",
+                            "nodeType": "USD::Attribute::add_attribute_connection",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "155 741"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "block_attribute",
+                            "nodeType": "USD::Attribute::block_attribute",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "365 741"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "clear_attribute",
+                            "nodeType": "USD::Attribute::clear_attribute",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "575 741"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "clear_attribute_connections",
+                            "nodeType": "USD::Attribute::clear_attribute_connections",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "785 741"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "create_prim_attribute",
+                            "nodeType": "USD::Attribute::create_prim_attribute",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "995 741"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "create_primvar",
+                            "nodeType": "USD::Attribute::create_primvar",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "1205 741"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "define_usd_attribute",
+                            "nodeType": "USD::Attribute::define_usd_attribute",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "1413.63 732.12"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "define_usd_display_color",
+                            "nodeType": "USD::Attribute::define_usd_display_color",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "1623.63 763.542"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "define_usd_transform",
+                            "nodeType": "USD::Attribute::define_usd_transform",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "1835 741"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "get_attribute_comment",
+                            "nodeType": "USD::Attribute::get_attribute_comment",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "2045 741"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "get_attribute_custom_data",
+                            "nodeType": "USD::Attribute::get_attribute_custom_data",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "155 1281"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "get_attribute_documentation",
+                            "nodeType": "USD::Attribute::get_attribute_documentation",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "365.683 1263.24"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "get_prim_attribute",
+                            "nodeType": "USD::Attribute::get_prim_attribute",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "575 1281"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "get_prim_attribute_data",
+                            "nodeType": "USD::Attribute::get_prim_attribute_data",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "785 1281"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "get_usd_attribute_value",
+                            "nodeType": "USD::Attribute::get_usd_attribute_value",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "995 1281"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "remove_attribute_connection",
+                            "nodeType": "USD::Attribute::remove_attribute_connection",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "1203.63 1258.46"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "set_attribute_comment",
+                            "nodeType": "USD::Attribute::set_attribute_comment",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "1415 1281"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "set_attribute_custom_data",
+                            "nodeType": "USD::Attribute::set_attribute_custom_data",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "1625 1281"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "set_attribute_documentation",
+                            "nodeType": "USD::Attribute::set_attribute_documentation",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "1833.63 1258.46"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "set_prim_attribute",
+                            "nodeType": "USD::Attribute::set_prim_attribute",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "2045 1281"
+                                }
+                            ]
+                        }
+                    ],
+                    "connections": [],
+                    "values": [
+                        {
+                            "valueName": "create_primvar.element_size",
+                            "valueType": "int",
+                            "value": "-1L"
+                        },
+                        {
+                            "valueName": "define_usd_attribute.name",
+                            "valueType": "string",
+                            "value": "info:id"
+                        },
+                        {
+                            "valueName": "define_usd_attribute.type",
+                            "valueType": "BifrostUsd::SdfValueTypeName",
+                            "value": "Token"
+                        },
+                        {
+                            "valueName": "define_usd_attribute.enable_value",
+                            "valueType": "bool",
+                            "value": "false"
+                        },
+                        {
+                            "valueName": "define_usd_attribute.enable_connection",
+                            "valueType": "bool",
+                            "value": "false"
+                        },
+                        {
+                            "valueName": "define_usd_attribute.connection_mode",
+                            "valueType": "BifrostUsd::RelationshipTarget",
+                            "value": "Add"
+                        },
+                        {
+                            "valueName": "define_usd_attribute.target_prim",
+                            "valueType": "string",
+                            "value": ""
+                        },
+                        {
+                            "valueName": "define_usd_attribute.target_attribute",
+                            "valueType": "string",
+                            "value": ""
+                        },
+                        {
+                            "valueName": "define_usd_attribute.enable_primvar",
+                            "valueType": "bool",
+                            "value": "false"
+                        },
+                        {
+                            "valueName": "define_usd_attribute.interpolation",
+                            "valueType": "BifrostUsd::UsdGeomPrimvarInterpolation",
+                            "value": "PrimVarConstant"
+                        },
+                        {
+                            "valueName": "define_usd_attribute.custom",
+                            "valueType": "bool",
+                            "value": "false"
+                        },
+                        {
+                            "valueName": "define_usd_attribute.use_frame",
+                            "valueType": "bool",
+                            "value": "false"
+                        },
+                        {
+                            "valueName": "define_usd_attribute.frame",
+                            "valueType": "float",
+                            "value": "0f"
+                        },
+                        {
+                            "valueName": "define_usd_display_color.color",
+                            "valueType": "Math::float3",
+                            "value": {
+                                "x": "0f",
+                                "y": "0f",
+                                "z": "1f"
+                            }
+                        },
+                        {
+                            "valueName": "define_usd_transform.translation",
+                            "valueType": "Math::float3",
+                            "value": {
+                                "x": "0f",
+                                "y": "0f",
+                                "z": "0f"
+                            }
+                        },
+                        {
+                            "valueName": "define_usd_transform.rotation",
+                            "valueType": "Math::float3",
+                            "value": {
+                                "x": "0f",
+                                "y": "0f",
+                                "z": "0f"
+                            }
+                        },
+                        {
+                            "valueName": "define_usd_transform.scale",
+                            "valueType": "Math::float3",
+                            "value": {
+                                "x": "1f",
+                                "y": "1f",
+                                "z": "1f"
+                            }
+                        },
+                        {
+                            "valueName": "get_attribute_comment.stage",
+                            "valueType": "BifrostUsd::Stage",
+                            "value": {}
+                        },
+                        {
+                            "valueName": "get_attribute_comment.prim_path",
+                            "valueType": "string",
+                            "value": ""
+                        },
+                        {
+                            "valueName": "get_attribute_comment.attribute_name",
+                            "valueType": "string",
+                            "value": ""
+                        },
+                        {
+                            "valueName": "get_attribute_custom_data.stage",
+                            "valueType": "BifrostUsd::Stage",
+                            "value": {}
+                        },
+                        {
+                            "valueName": "get_attribute_custom_data.prim_path",
+                            "valueType": "string",
+                            "value": "/hello/world"
+                        },
+                        {
+                            "valueName": "get_attribute_custom_data.attribute_name",
+                            "valueType": "string",
+                            "value": "myMetaAttribute"
+                        },
+                        {
+                            "valueName": "get_attribute_documentation.stage",
+                            "valueType": "BifrostUsd::Stage",
+                            "value": {}
+                        },
+                        {
+                            "valueName": "get_attribute_documentation.prim_path",
+                            "valueType": "string",
+                            "value": ""
+                        },
+                        {
+                            "valueName": "get_attribute_documentation.attribute_name",
+                            "valueType": "string",
+                            "value": ""
+                        },
+                        {
+                            "valueName": "get_prim_attribute_data.type",
+                            "valueType": "float",
+                            "value": "0f"
+                        },
+                        {
+                            "valueName": "get_usd_attribute_value.stage",
+                            "valueType": "BifrostUsd::Stage",
+                            "value": {}
+                        },
+                        {
+                            "valueName": "get_usd_attribute_value.prim_path",
+                            "valueType": "string",
+                            "value": ""
+                        },
+                        {
+                            "valueName": "get_usd_attribute_value.attribute_name",
+                            "valueType": "string",
+                            "value": ""
+                        },
+                        {
+                            "valueName": "get_usd_attribute_value.type",
+                            "valueType": "array<float>",
+                            "value": []
+                        },
+                        {
+                            "valueName": "get_usd_attribute_value.frame",
+                            "valueType": "float",
+                            "value": "0f"
+                        },
+                        {
+                            "valueName": "set_attribute_comment.stage",
+                            "valueType": "BifrostUsd::Stage",
+                            "value": {}
+                        },
+                        {
+                            "valueName": "set_attribute_comment.prim_path",
+                            "valueType": "string",
+                            "value": ""
+                        },
+                        {
+                            "valueName": "set_attribute_comment.attribute_name",
+                            "valueType": "string",
+                            "value": ""
+                        },
+                        {
+                            "valueName": "set_attribute_comment.value",
+                            "valueType": "string",
+                            "value": ""
+                        },
+                        {
+                            "valueName": "set_attribute_custom_data.stage",
+                            "valueType": "BifrostUsd::Stage",
+                            "value": {}
+                        },
+                        {
+                            "valueName": "set_attribute_custom_data.prim_path",
+                            "valueType": "string",
+                            "value": ""
+                        },
+                        {
+                            "valueName": "set_attribute_custom_data.attribute_name",
+                            "valueType": "string",
+                            "value": ""
+                        },
+                        {
+                            "valueName": "set_attribute_custom_data.value",
+                            "valueType": "Object",
+                            "value": {}
+                        },
+                        {
+                            "valueName": "set_attribute_documentation.stage",
+                            "valueType": "BifrostUsd::Stage",
+                            "value": {}
+                        },
+                        {
+                            "valueName": "set_attribute_documentation.prim_path",
+                            "valueType": "string",
+                            "value": ""
+                        },
+                        {
+                            "valueName": "set_attribute_documentation.attribute_name",
+                            "valueType": "string",
+                            "value": ""
+                        },
+                        {
+                            "valueName": "set_attribute_documentation.value",
+                            "valueType": "string",
+                            "value": ""
+                        },
+                        {
+                            "valueName": "set_prim_attribute.value",
+                            "valueType": "Math::float3",
+                            "value": {
+                                "x": "0f",
+                                "y": "0f",
+                                "z": "0f"
+                            }
+                        }
+                    ],
+                    "reservedNodeNames": [
+                        {
+                            "name": "input"
+                        },
+                        {
+                            "name": "output"
+                        }
+                    ]
+                },
+                {
+                    "name": "prim_compounds_and_nodedefs",
+                    "uriImported": "file:///load_all_compounds_test00.json",
+                    "metadata": [
+                        {
+                            "metaName": "io_nodes",
+                            "metadata": [
+                                {
+                                    "metaName": "io_inodes",
+                                    "metadata": [
+                                        {
+                                            "metaName": "input",
+                                            "metadata": [
+                                                {
+                                                    "metaName": "DisplayMode",
+                                                    "metaType": "string",
+                                                    "metaValue": "2"
+                                                },
+                                                {
+                                                    "metaName": "LayoutPos",
+                                                    "metaType": "string",
+                                                    "metaValue": "309 -1729"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "metaName": "io_onodes",
+                                    "metadata": [
+                                        {
+                                            "metaName": "output",
+                                            "metadata": [
+                                                {
+                                                    "metaName": "DisplayMode",
+                                                    "metaType": "string",
+                                                    "metaValue": "2"
+                                                },
+                                                {
+                                                    "metaName": "LayoutPos",
+                                                    "metaType": "string",
+                                                    "metaValue": "549 -1732"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "metaName": "_recentNode_",
+                            "metaType": "string",
+                            "metaValue": "BifrostGraph,USD::Prim,set_prim_asset_info"
+                        },
+                        {
+                            "metaName": "_recentNode_",
+                            "metaType": "string",
+                            "metaValue": "BifrostGraph,USD::Prim,get_prim_asset_info"
+                        },
+                        {
+                            "metaName": "_recentNode_",
+                            "metaType": "string",
+                            "metaValue": "BifrostGraph,USD::Prim,define_usd_reference_from_file"
+                        },
+                        {
+                            "metaName": "_recentNode_",
+                            "metaType": "string",
+                            "metaValue": "BifrostGraph,USD::IO,read_usd_curves"
+                        },
+                        {
+                            "metaName": "_recentNode_",
+                            "metaType": "string",
+                            "metaValue": "BifrostGraph,USD::Utils,create_child_prim_path"
+                        },
+                        {
+                            "metaName": "ViewportRect",
+                            "metaType": "string",
+                            "metaValue": "-1191.24 -1772 5099.81 2994.67"
+                        }
+                    ],
+                    "ports": [],
+                    "compoundNodes": [
+                        {
+                            "nodeName": "add_inherit_prim",
+                            "nodeType": "USD::Prim::add_inherit_prim",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "308.675 -1521.36"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "add_payload_prim",
+                            "nodeType": "USD::Prim::add_payload_prim",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "518.675 -1521.36"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "add_reference_prim",
+                            "nodeType": "USD::Prim::add_reference_prim",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "728.675 -1521.36"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "add_relationship_target",
+                            "nodeType": "USD::Prim::add_relationship_target",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "938.675 -1521.36"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "add_specialize_prim",
+                            "nodeType": "USD::Prim::add_specialize_prim",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "1148.68 -1521.36"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "build_prim_from_definition",
+                            "nodeType": "USD::Prim::build_prim_from_definition",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "1358.67 -1521.36"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "clear_relationship_targets",
+                            "nodeType": "USD::Prim::clear_relationship_targets",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "1568.67 -1521.36"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "compute_usdgeom_extent",
+                            "nodeType": "USD::Prim::compute_usdgeom_extent",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "1778.67 -1521.36"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "create_class_prim",
+                            "nodeType": "USD::Prim::create_class_prim",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "1988.67 -1521.36"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "create_prim_relationship",
+                            "nodeType": "USD::Prim::create_prim_relationship",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "2198.67 -1521.36"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "create_usd_prim",
+                            "nodeType": "USD::Prim::create_usd_prim",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "308.675 -1191.36"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "define_usd_curves",
+                            "nodeType": "USD::Prim::define_usd_curves",
+                            "fanInPortNames": {
+                                "attribute_definitions": [],
+                                "reference_definitions": [],
+                                "relationship_definitions": [],
+                                "children": []
+                            },
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "518.675 -1191.36"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "define_usd_mesh",
+                            "nodeType": "USD::Prim::define_usd_mesh",
+                            "fanInPortNames": {
+                                "attribute_definitions": [],
+                                "reference_definitions": [],
+                                "relationship_definitions": [],
+                                "children": []
+                            },
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "728.675 -1191.36"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "define_usd_point_instancer",
+                            "nodeType": "USD::Prim::define_usd_point_instancer",
+                            "fanInPortNames": {
+                                "prototype_definitions": []
+                            },
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "938.675 -1191.36"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "define_usd_prim",
+                            "nodeType": "USD::Prim::define_usd_prim",
+                            "fanInPortNames": {
+                                "attribute_definitions": [],
+                                "reference_definitions": [],
+                                "relationship_definitions": [],
+                                "variant_set_definitions": [],
+                                "children": []
+                            },
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "1148.68 -1169.93"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "define_usd_reference",
+                            "nodeType": "USD::Prim::define_usd_reference",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "1358.67 -1191.36"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "define_usd_relationship",
+                            "nodeType": "USD::Prim::define_usd_relationship",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "1797.07 -1187.98"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "duplicate_usd_prim_definition",
+                            "nodeType": "USD::Prim::duplicate_usd_prim_definition",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "2012.97 -1159.52"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "get_forwarded_relationship_targets",
+                            "nodeType": "USD::Prim::get_forwarded_relationship_targets",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "2214.09 -1141.65"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "get_last_modified_prim",
+                            "nodeType": "USD::Prim::get_last_modified_prim",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "300.327 -817.694"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "get_prim_at_path",
+                            "nodeType": "USD::Prim::get_prim_at_path",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "300.928 -547.6"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "get_prim_children",
+                            "nodeType": "USD::Prim::get_prim_children",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "510.928 -547.6"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "get_prim_comment",
+                            "nodeType": "USD::Prim::get_prim_comment",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "720.928 -547.6"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "get_prim_custom_data",
+                            "nodeType": "USD::Prim::get_prim_custom_data",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "930.928 -547.6"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "get_prim_documentation",
+                            "nodeType": "USD::Prim::get_prim_documentation",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "1140.93 -547.6"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "get_prim_in_prototype",
+                            "nodeType": "USD::Prim::get_prim_in_prototype",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "1350.92 -547.6"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "get_prim_instances",
+                            "nodeType": "USD::Prim::get_prim_instances",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "1560.92 -547.6"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "get_prim_path",
+                            "nodeType": "USD::Prim::get_prim_path",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "1770.92 -547.6"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "get_prim_type",
+                            "nodeType": "USD::Prim::get_prim_type",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "1980.92 -547.6"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "get_prototype_prims",
+                            "nodeType": "USD::Prim::get_prototype_prims",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "2190.92 -547.6"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "get_relationship_targets",
+                            "nodeType": "USD::Prim::get_relationship_targets",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "300.928 -247.6"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "get_usd_geom_points",
+                            "nodeType": "USD::Prim::get_usd_geom_points",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "510.928 -247.6"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "get_usd_geom_xform_vectors",
+                            "nodeType": "USD::Prim::get_usd_geom_xform_vectors",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "719.397 -269.034"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "override_prim",
+                            "nodeType": "USD::Prim::override_prim",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "930.928 -247.6"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "prim_clear_instanceable",
+                            "nodeType": "USD::Prim::prim_clear_instanceable",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "1140.93 -247.6"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "prim_get_prototype",
+                            "nodeType": "USD::Prim::prim_get_prototype",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "1350.92 -247.6"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "prim_has_authored_instanceable",
+                            "nodeType": "USD::Prim::prim_has_authored_instanceable",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "1560.92 -275.158"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "prim_is_in_prototype",
+                            "nodeType": "USD::Prim::prim_is_in_prototype",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "1770.92 -247.6"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "prim_is_instance",
+                            "nodeType": "USD::Prim::prim_is_instance",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "1980.92 -247.6"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "prim_is_instance_proxy",
+                            "nodeType": "USD::Prim::prim_is_instance_proxy",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "2190.92 -247.6"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "prim_is_instanceable",
+                            "nodeType": "USD::Prim::prim_is_instanceable",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "300.928 112.4"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "prim_is_prototype",
+                            "nodeType": "USD::Prim::prim_is_prototype",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "510.928 112.4"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "remove_payload_prim",
+                            "nodeType": "USD::Prim::remove_payload_prim",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "720.928 112.4"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "remove_reference_prim",
+                            "nodeType": "USD::Prim::remove_reference_prim",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "930.928 112.4"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "remove_relationship_target",
+                            "nodeType": "USD::Prim::remove_relationship_target",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "1140.93 112.4"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "rotate_prim",
+                            "nodeType": "USD::Prim::rotate_prim",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "1350.92 112.4"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "scale_prim",
+                            "nodeType": "USD::Prim::scale_prim",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "1560.92 112.4"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "set_prim_active",
+                            "nodeType": "USD::Prim::set_prim_active",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "1770.92 112.4"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "set_prim_color",
+                            "nodeType": "USD::Prim::set_prim_color",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "2207.79 111.319"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "set_prim_comment",
+                            "nodeType": "USD::Prim::set_prim_comment",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "292.743 461.353"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "set_prim_custom_data",
+                            "nodeType": "USD::Prim::set_prim_custom_data",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "511.596 458.605"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "set_prim_documentation",
+                            "nodeType": "USD::Prim::set_prim_documentation",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "721.596 458.605"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "set_prim_instanceable",
+                            "nodeType": "USD::Prim::set_prim_instanceable",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "931.596 458.605"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "set_prim_pivot",
+                            "nodeType": "USD::Prim::set_prim_pivot",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "1141.6 458.605"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "set_prim_purpose",
+                            "nodeType": "USD::Prim::set_prim_purpose",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "1351.6 458.605"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "set_relationship_targets",
+                            "nodeType": "USD::Prim::set_relationship_targets",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "1561.59 458.605"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "set_usd_default_prim",
+                            "nodeType": "USD::Prim::set_usd_default_prim",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "1771.59 458.605"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "set_usd_prim_kind",
+                            "nodeType": "USD::Prim::set_usd_prim_kind",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "1981.59 458.605"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "translate_prim",
+                            "nodeType": "USD::Prim::translate_prim",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "2191.59 458.605"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "usd_point_instancer",
+                            "nodeType": "USD::Prim::usd_point_instancer",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "277.617 742.737"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "usd_volume",
+                            "nodeType": "USD::Prim::usd_volume",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "521.319 743.727"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "define_usd_reference_from_file",
+                            "nodeType": "USD::Prim::define_usd_reference_from_file",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "1573.96 -1191.21"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "get_prim_asset_info",
+                            "nodeType": "USD::Prim::get_prim_asset_info",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "516.839 -823.052"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "set_prim_asset_info",
+                            "nodeType": "USD::Prim::set_prim_asset_info",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "1987.17 113.174"
+                                }
+                            ]
+                        }
+                    ],
+                    "connections": [],
+                    "values": [
+                        {
+                            "valueName": "add_payload_prim.layer_offset",
+                            "valueType": "double",
+                            "value": "0"
+                        },
+                        {
+                            "valueName": "add_payload_prim.layer_scale",
+                            "valueType": "double",
+                            "value": "1"
+                        },
+                        {
+                            "valueName": "add_reference_prim.layer_offset",
+                            "valueType": "double",
+                            "value": "0"
+                        },
+                        {
+                            "valueName": "add_reference_prim.layer_scale",
+                            "valueType": "double",
+                            "value": "1"
+                        },
+                        {
+                            "valueName": "build_prim_from_definition.stage",
+                            "valueType": "BifrostUsd::Stage",
+                            "value": {}
+                        },
+                        {
+                            "valueName": "build_prim_from_definition.prim_def",
+                            "valueType": "Object",
+                            "value": {}
+                        },
+                        {
+                            "valueName": "compute_usdgeom_extent.frame",
+                            "valueType": "float",
+                            "value": "1f"
+                        },
+                        {
+                            "valueName": "compute_usdgeom_extent.local",
+                            "valueType": "bool",
+                            "value": "true"
+                        },
+                        {
+                            "valueName": "create_usd_prim.path",
+                            "valueType": "string",
+                            "value": ""
+                        },
+                        {
+                            "valueName": "create_usd_prim.type",
+                            "valueType": "string",
+                            "value": ""
+                        },
+                        {
+                            "valueName": "define_usd_curves.path",
+                            "valueType": "string",
+                            "value": "/curves"
+                        },
+                        {
+                            "valueName": "define_usd_curves.strands",
+                            "valueType": "Object",
+                            "value": {}
+                        },
+                        {
+                            "valueName": "define_usd_curves.attribute_definitions",
+                            "valueType": "array<Object>",
+                            "value": []
+                        },
+                        {
+                            "valueName": "define_usd_curves.reference_definitions",
+                            "valueType": "array<Object>",
+                            "value": []
+                        },
+                        {
+                            "valueName": "define_usd_curves.relationship_definitions",
+                            "valueType": "array<Object>",
+                            "value": []
+                        },
+                        {
+                            "valueName": "define_usd_curves.children",
+                            "valueType": "array<Object>",
+                            "value": []
+                        },
+                        {
+                            "valueName": "define_usd_curves.material",
+                            "valueType": "Object",
+                            "value": {}
+                        },
+                        {
+                            "valueName": "define_usd_curves.basis",
+                            "valueType": "string",
+                            "value": "catmullRom"
+                        },
+                        {
+                            "valueName": "define_usd_curves.type",
+                            "valueType": "string",
+                            "value": "cubic"
+                        },
+                        {
+                            "valueName": "define_usd_mesh.path",
+                            "valueType": "string",
+                            "value": "/mesh"
+                        },
+                        {
+                            "valueName": "define_usd_mesh.mesh",
+                            "valueType": "Object",
+                            "value": {}
+                        },
+                        {
+                            "valueName": "define_usd_mesh.subdivision_scheme",
+                            "valueType": "BifrostUsd::SubdivisionScheme",
+                            "value": "catmullClark"
+                        },
+                        {
+                            "valueName": "define_usd_mesh.attribute_definitions",
+                            "valueType": "array<Object>",
+                            "value": []
+                        },
+                        {
+                            "valueName": "define_usd_mesh.reference_definitions",
+                            "valueType": "array<Object>",
+                            "value": []
+                        },
+                        {
+                            "valueName": "define_usd_mesh.relationship_definitions",
+                            "valueType": "array<Object>",
+                            "value": []
+                        },
+                        {
+                            "valueName": "define_usd_mesh.children",
+                            "valueType": "array<Object>",
+                            "value": []
+                        },
+                        {
+                            "valueName": "define_usd_mesh.material",
+                            "valueType": "Object",
+                            "value": {}
+                        },
+                        {
+                            "valueName": "define_usd_mesh.normal_per_vertex",
+                            "valueType": "bool",
+                            "value": "true"
+                        },
+                        {
+                            "valueName": "define_usd_mesh.variant_set_name",
+                            "valueType": "string",
+                            "value": ""
+                        },
+                        {
+                            "valueName": "define_usd_mesh.variant_name",
+                            "valueType": "string",
+                            "value": ""
+                        },
+                        {
+                            "valueName": "define_usd_mesh.use_frame",
+                            "valueType": "bool",
+                            "value": "false"
+                        },
+                        {
+                            "valueName": "define_usd_mesh.frame",
+                            "valueType": "float",
+                            "value": "0f"
+                        },
+                        {
+                            "valueName": "define_usd_point_instancer.instancer_path",
+                            "valueType": "string",
+                            "value": "/instancer"
+                        },
+                        {
+                            "valueName": "define_usd_point_instancer.points",
+                            "valueType": "Object",
+                            "value": {}
+                        },
+                        {
+                            "valueName": "define_usd_point_instancer.prototype_definitions",
+                            "valueType": "array<Object>",
+                            "value": []
+                        },
+                        {
+                            "valueName": "define_usd_point_instancer.create_default_material",
+                            "valueType": "bool",
+                            "value": "true"
+                        },
+                        {
+                            "valueName": "define_usd_point_instancer.diffuse_color",
+                            "valueType": "Math::float3",
+                            "value": {
+                                "x": "0.50999999f",
+                                "y": "0.540000021f",
+                                "z": "0.600000024f"
+                            }
+                        },
+                        {
+                            "valueName": "define_usd_point_instancer.texture_file_path",
+                            "valueType": "string",
+                            "value": ""
+                        },
+                        {
+                            "valueName": "define_usd_point_instancer.selection_mode",
+                            "valueType": "Modeling::Points::CreateInstancesSelectionMode",
+                            "value": "Sequential"
+                        },
+                        {
+                            "valueName": "define_usd_point_instancer.instance_id_override",
+                            "valueType": "array<long>",
+                            "value": []
+                        },
+                        {
+                            "valueName": "define_usd_point_instancer.probability_curve",
+                            "valueType": "Math::FCurve",
+                            "value": {
+                                "version": "1",
+                                "preExtrapolation": "0",
+                                "postExtrapolation": "0",
+                                "points": [
+                                    {
+                                        "point": {
+                                            "locked": "1",
+                                            "interpolation": "1",
+                                            "pcn": {
+                                                "xp": "-0.63807499999999995",
+                                                "yp": "-0.180645",
+                                                "x": "0",
+                                                "y": "0",
+                                                "xn": "0.63807499999999995",
+                                                "yn": "0.180645"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "point": {
+                                            "locked": "1",
+                                            "interpolation": "1",
+                                            "pcn": {
+                                                "xp": "0.67824300000000004",
+                                                "yp": "0.91612899999999997",
+                                                "x": "1",
+                                                "y": "1",
+                                                "xn": "1.3217570000000001",
+                                                "yn": "1.083871"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "valueName": "define_usd_point_instancer.seed",
+                            "valueType": "long",
+                            "value": "354"
+                        },
+                        {
+                            "valueName": "define_usd_point_instancer.frame",
+                            "valueType": "float",
+                            "value": "0f"
+                        },
+                        {
+                            "valueName": "define_usd_point_instancer.use_frame",
+                            "valueType": "bool",
+                            "value": "false"
+                        },
+                        {
+                            "valueName": "define_usd_prim.path",
+                            "valueType": "string",
+                            "value": "/obj"
+                        },
+                        {
+                            "valueName": "define_usd_prim.type",
+                            "valueType": "string",
+                            "value": "Xform"
+                        },
+                        {
+                            "valueName": "define_usd_prim.specifier",
+                            "valueType": "BifrostUsd::SdfSpecifier",
+                            "value": "Def"
+                        },
+                        {
+                            "valueName": "define_usd_prim.kind",
+                            "valueType": "BifrostUsd::ModelKind",
+                            "value": "None"
+                        },
+                        {
+                            "valueName": "define_usd_prim.active",
+                            "valueType": "BifrostUsd::ActivatePrim",
+                            "value": "None"
+                        },
+                        {
+                            "valueName": "define_usd_prim.instanceable",
+                            "valueType": "BifrostUsd::InstanceablePrim",
+                            "value": "None"
+                        },
+                        {
+                            "valueName": "define_usd_prim.purpose",
+                            "valueType": "BifrostUsd::ImageablePurpose",
+                            "value": "Default"
+                        },
+                        {
+                            "valueName": "define_usd_prim.attribute_definitions",
+                            "valueType": "array<Object>",
+                            "value": []
+                        },
+                        {
+                            "valueName": "define_usd_prim.reference_definitions",
+                            "valueType": "array<Object>",
+                            "value": []
+                        },
+                        {
+                            "valueName": "define_usd_prim.relationship_definitions",
+                            "valueType": "array<Object>",
+                            "value": []
+                        },
+                        {
+                            "valueName": "define_usd_prim.variant_set_definitions",
+                            "valueType": "array<Object>",
+                            "value": []
+                        },
+                        {
+                            "valueName": "define_usd_prim.children",
+                            "valueType": "array<Object>",
+                            "value": []
+                        },
+                        {
+                            "valueName": "define_usd_prim.material",
+                            "valueType": "Object",
+                            "value": {}
+                        },
+                        {
+                            "valueName": "define_usd_prim.variant_set_name",
+                            "valueType": "string",
+                            "value": ""
+                        },
+                        {
+                            "valueName": "define_usd_prim.variant_name",
+                            "valueType": "string",
+                            "value": ""
+                        },
+                        {
+                            "valueName": "define_usd_reference.arc_type",
+                            "valueType": "BifrostUsd::ArcType",
+                            "value": "Reference"
+                        },
+                        {
+                            "valueName": "define_usd_reference.prim_path",
+                            "valueType": "string",
+                            "value": ""
+                        },
+                        {
+                            "valueName": "define_usd_reference.relative_prim_path",
+                            "valueType": "bool",
+                            "value": "false"
+                        },
+                        {
+                            "valueName": "define_usd_reference.layer",
+                            "valueType": "BifrostUsd::Layer",
+                            "value": {}
+                        },
+                        {
+                            "valueName": "define_usd_reference.layer_offset",
+                            "valueType": "double",
+                            "value": "0"
+                        },
+                        {
+                            "valueName": "define_usd_reference.layer_scale",
+                            "valueType": "double",
+                            "value": "1"
+                        },
+                        {
+                            "valueName": "define_usd_reference.position",
+                            "valueType": "BifrostUsd::UsdListPosition",
+                            "value": "UsdListPositionFrontOfPrependList"
+                        },
+                        {
+                            "valueName": "define_usd_relationship.rel_name",
+                            "valueType": "string",
+                            "value": "material:binding"
+                        },
+                        {
+                            "valueName": "define_usd_relationship.target",
+                            "valueType": "string",
+                            "value": "/Material"
+                        },
+                        {
+                            "valueName": "define_usd_relationship.local_path",
+                            "valueType": "bool",
+                            "value": "false"
+                        },
+                        {
+                            "valueName": "duplicate_usd_prim_definition.prim_definition",
+                            "valueType": "Object",
+                            "value": {}
+                        },
+                        {
+                            "valueName": "duplicate_usd_prim_definition.arc_type",
+                            "valueType": "BifrostUsd::ArcType",
+                            "value": "Reference"
+                        },
+                        {
+                            "valueName": "duplicate_usd_prim_definition.instanceable",
+                            "valueType": "BifrostUsd::InstanceablePrim",
+                            "value": "True"
+                        },
+                        {
+                            "valueName": "duplicate_usd_prim_definition.duplicate_name",
+                            "valueType": "string",
+                            "value": ""
+                        },
+                        {
+                            "valueName": "duplicate_usd_prim_definition.count",
+                            "valueType": "long",
+                            "value": "14"
+                        },
+                        {
+                            "valueName": "duplicate_usd_prim_definition.uniform_scale",
+                            "valueType": "bool",
+                            "value": "false"
+                        },
+                        {
+                            "valueName": "get_prim_comment.stage",
+                            "valueType": "BifrostUsd::Stage",
+                            "value": {}
+                        },
+                        {
+                            "valueName": "get_prim_comment.path",
+                            "valueType": "string",
+                            "value": ""
+                        },
+                        {
+                            "valueName": "get_prim_custom_data.stage",
+                            "valueType": "BifrostUsd::Stage",
+                            "value": {}
+                        },
+                        {
+                            "valueName": "get_prim_custom_data.path",
+                            "valueType": "string",
+                            "value": ""
+                        },
+                        {
+                            "valueName": "get_prim_documentation.stage",
+                            "valueType": "BifrostUsd::Stage",
+                            "value": {}
+                        },
+                        {
+                            "valueName": "get_prim_documentation.path",
+                            "valueType": "string",
+                            "value": ""
+                        },
+                        {
+                            "valueName": "get_usd_geom_points.frame",
+                            "valueType": "float",
+                            "value": "1f"
+                        },
+                        {
+                            "valueName": "get_usd_geom_xform_vectors.frame",
+                            "valueType": "float",
+                            "value": "1f"
+                        },
+                        {
+                            "valueName": "remove_payload_prim.layer_offset",
+                            "valueType": "double",
+                            "value": "0"
+                        },
+                        {
+                            "valueName": "remove_reference_prim.layer_offset",
+                            "valueType": "double",
+                            "value": "0"
+                        },
+                        {
+                            "valueName": "scale_prim.scale",
+                            "valueType": "Math::float3",
+                            "value": {
+                                "x": "1f",
+                                "y": "1f",
+                                "z": "1f"
+                            }
+                        },
+                        {
+                            "valueName": "set_prim_color.name",
+                            "valueType": "string",
+                            "value": "primvars:displayColor"
+                        },
+                        {
+                            "valueName": "set_prim_comment.stage",
+                            "valueType": "BifrostUsd::Stage",
+                            "value": {}
+                        },
+                        {
+                            "valueName": "set_prim_comment.path",
+                            "valueType": "string",
+                            "value": ""
+                        },
+                        {
+                            "valueName": "set_prim_comment.value",
+                            "valueType": "string",
+                            "value": ""
+                        },
+                        {
+                            "valueName": "set_prim_documentation.stage",
+                            "valueType": "BifrostUsd::Stage",
+                            "value": {}
+                        },
+                        {
+                            "valueName": "set_prim_documentation.path",
+                            "valueType": "string",
+                            "value": ""
+                        },
+                        {
+                            "valueName": "set_prim_documentation.value",
+                            "valueType": "string",
+                            "value": ""
+                        },
+                        {
+                            "valueName": "set_usd_default_prim.prim_path",
+                            "valueType": "string",
+                            "value": ""
+                        },
+                        {
+                            "valueName": "set_usd_prim_kind.path",
+                            "valueType": "string",
+                            "value": ""
+                        },
+                        {
+                            "valueName": "set_usd_prim_kind.kind",
+                            "valueType": "string",
+                            "value": "component"
+                        },
+                        {
+                            "valueName": "usd_volume.frame",
+                            "valueType": "float",
+                            "value": "1f"
+                        }
+                    ],
+                    "reservedNodeNames": [
+                        {
+                            "name": "input"
+                        },
+                        {
+                            "name": "output"
+                        }
+                    ]
+                },
+                {
+                    "name": "collection_compounds_and_nodedefs",
+                    "uriImported": "file:///load_all_compounds_test00.json",
+                    "metadata": [
+                        {
+                            "metaName": "io_nodes",
+                            "metadata": [
+                                {
+                                    "metaName": "io_inodes",
+                                    "metadata": [
+                                        {
+                                            "metaName": "input",
+                                            "metadata": [
+                                                {
+                                                    "metaName": "DisplayMode",
+                                                    "metaType": "string",
+                                                    "metaValue": "2"
+                                                },
+                                                {
+                                                    "metaName": "LayoutPos",
+                                                    "metaType": "string",
+                                                    "metaValue": "-381 -382"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "metaName": "io_onodes",
+                                    "metadata": [
+                                        {
+                                            "metaName": "output",
+                                            "metadata": [
+                                                {
+                                                    "metaName": "DisplayMode",
+                                                    "metaType": "string",
+                                                    "metaValue": "2"
+                                                },
+                                                {
+                                                    "metaName": "LayoutPos",
+                                                    "metaType": "string",
+                                                    "metaValue": "-141 -382"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "metaName": "ViewportRect",
+                            "metaType": "string",
+                            "metaValue": "-1110 -652 2220.67 1304"
+                        }
+                    ],
+                    "ports": [],
+                    "compoundNodes": [
+                        {
+                            "nodeName": "get_all_collection_names",
+                            "nodeType": "USD::Collection::get_all_collection_names",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "-381 -172"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "get_excludes_paths",
+                            "nodeType": "USD::Collection::get_excludes_paths",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "-171 -172"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "get_includes_paths",
+                            "nodeType": "USD::Collection::get_includes_paths",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "39 -172"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "get_or_create_collection",
+                            "nodeType": "USD::Collection::get_or_create_collection",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "249 -172"
+                                }
+                            ]
+                        }
+                    ],
+                    "connections": [],
+                    "values": [],
+                    "reservedNodeNames": [
+                        {
+                            "name": "input"
+                        },
+                        {
+                            "name": "output"
+                        }
+                    ]
+                },
+                {
+                    "name": "layer_compounds_and_nodedefs",
+                    "uriImported": "file:///load_all_compounds_test00.json",
+                    "metadata": [
+                        {
+                            "metaName": "io_nodes",
+                            "metadata": [
+                                {
+                                    "metaName": "io_inodes",
+                                    "metadata": [
+                                        {
+                                            "metaName": "input",
+                                            "metadata": [
+                                                {
+                                                    "metaName": "DisplayMode",
+                                                    "metaType": "string",
+                                                    "metaValue": "2"
+                                                },
+                                                {
+                                                    "metaName": "LayoutPos",
+                                                    "metaType": "string",
+                                                    "metaValue": "-861 -562"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "metaName": "io_onodes",
+                                    "metadata": [
+                                        {
+                                            "metaName": "output",
+                                            "metadata": [
+                                                {
+                                                    "metaName": "DisplayMode",
+                                                    "metaType": "string",
+                                                    "metaValue": "2"
+                                                },
+                                                {
+                                                    "metaName": "LayoutPos",
+                                                    "metaType": "string",
+                                                    "metaValue": "-621 -562"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "metaName": "ViewportRect",
+                            "metaType": "string",
+                            "metaValue": "-1110 -652 2220.67 1304"
+                        }
+                    ],
+                    "ports": [],
+                    "compoundNodes": [
+                        {
+                            "nodeName": "add_sublayer",
+                            "nodeType": "USD::Layer::add_sublayer",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "-861 -352"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "create_usd_layer",
+                            "nodeType": "USD::Layer::create_usd_layer",
+                            "fanInPortNames": {
+                                "sublayers": []
+                            },
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "-651 -352"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "duplicate_layer",
+                            "nodeType": "USD::Layer::duplicate_layer",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "-441 -352"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "export_layer_to_file",
+                            "nodeType": "USD::Layer::export_layer_to_file",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "-231 -352"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "export_layer_to_string",
+                            "nodeType": "USD::Layer::export_layer_to_string",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "-21 -352"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "get_layer",
+                            "nodeType": "USD::Layer::get_layer",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "189 -352"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "get_layer_file_path",
+                            "nodeType": "USD::Layer::get_layer_file_path",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "399 -352"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "get_layer_identifier",
+                            "nodeType": "USD::Layer::get_layer_identifier",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "609 -352"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "get_root_layer",
+                            "nodeType": "USD::Layer::get_root_layer",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "-861 -112"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "get_sublayer_paths",
+                            "nodeType": "USD::Layer::get_sublayer_paths",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "-651 -112"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "open_layer",
+                            "nodeType": "USD::Layer::open_layer",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "-441 -112"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "open_usd_layer",
+                            "nodeType": "USD::Layer::open_usd_layer",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "-231 -112"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "replace_layer",
+                            "nodeType": "USD::Layer::replace_layer",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "-21 -112"
+                                }
+                            ]
+                        }
+                    ],
+                    "connections": [],
+                    "values": [
+                        {
+                            "valueName": "create_usd_layer.sublayers",
+                            "valueType": "array<BifrostUsd::Layer>",
+                            "value": []
+                        },
+                        {
+                            "valueName": "export_layer_to_file.relative_path",
+                            "valueType": "bool",
+                            "value": "true"
+                        },
+                        {
+                            "valueName": "open_layer.read_only",
+                            "valueType": "bool",
+                            "value": "false"
+                        },
+                        {
+                            "valueName": "open_usd_layer.file",
+                            "valueType": "string",
+                            "value": ""
+                        },
+                        {
+                            "valueName": "open_usd_layer.read_only",
+                            "valueType": "bool",
+                            "value": "true"
+                        },
+                        {
+                            "valueName": "open_usd_layer.save_file",
+                            "valueType": "string",
+                            "value": ""
+                        }
+                    ],
+                    "reservedNodeNames": [
+                        {
+                            "name": "input"
+                        },
+                        {
+                            "name": "output"
+                        }
+                    ]
+                },
+                {
+                    "name": "shading_compounds_and_nodedefs",
+                    "uriImported": "file:///load_all_compounds_test00.json",
+                    "metadata": [
+                        {
+                            "metaName": "io_nodes",
+                            "metadata": [
+                                {
+                                    "metaName": "io_inodes",
+                                    "metadata": [
+                                        {
+                                            "metaName": "input",
+                                            "metadata": [
+                                                {
+                                                    "metaName": "DisplayMode",
+                                                    "metaType": "string",
+                                                    "metaValue": "2"
+                                                },
+                                                {
+                                                    "metaName": "LayoutPos",
+                                                    "metaType": "string",
+                                                    "metaValue": "-561 -262"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "metaName": "io_onodes",
+                                    "metadata": [
+                                        {
+                                            "metaName": "output",
+                                            "metadata": [
+                                                {
+                                                    "metaName": "DisplayMode",
+                                                    "metaType": "string",
+                                                    "metaValue": "2"
+                                                },
+                                                {
+                                                    "metaName": "LayoutPos",
+                                                    "metaType": "string",
+                                                    "metaValue": "-321 -262"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "metaName": "ViewportRect",
+                            "metaType": "string",
+                            "metaValue": "-1110 -652 2220.67 1304"
+                        }
+                    ],
+                    "ports": [],
+                    "compoundNodes": [
+                        {
+                            "nodeName": "bind_material",
+                            "nodeType": "USD::Shading::bind_material",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "-561 -52"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "define_usd_material_tag",
+                            "nodeType": "USD::Shading::define_usd_material_tag",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "-351 -52"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "define_usd_preview_surface",
+                            "nodeType": "USD::Shading::define_usd_preview_surface",
+                            "fanInPortNames": {
+                                "attribute_definitions": []
+                            },
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "-141.667 -73.3333"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "get_material_path",
+                            "nodeType": "USD::Shading::get_material_path",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "69 -52"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "unbind_material",
+                            "nodeType": "USD::Shading::unbind_material",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "279 -52"
+                                }
+                            ]
+                        }
+                    ],
+                    "connections": [],
+                    "values": [
+                        {
+                            "valueName": "define_usd_preview_surface.path",
+                            "valueType": "string",
+                            "value": "/PreviewMaterial"
+                        },
+                        {
+                            "valueName": "define_usd_preview_surface.diffuse_color",
+                            "valueType": "Math::float3",
+                            "value": {
+                                "x": "0.236699998f",
+                                "y": "0.360000014f",
+                                "z": "0.796700001f"
+                            }
+                        },
+                        {
+                            "valueName": "define_usd_preview_surface.emissive_color",
+                            "valueType": "Math::float3",
+                            "value": {
+                                "x": "0f",
+                                "y": "0f",
+                                "z": "0f"
+                            }
+                        },
+                        {
+                            "valueName": "define_usd_preview_surface.metallic",
+                            "valueType": "float",
+                            "value": "0f"
+                        },
+                        {
+                            "valueName": "define_usd_preview_surface.roughness",
+                            "valueType": "float",
+                            "value": "0.460000008f"
+                        },
+                        {
+                            "valueName": "define_usd_preview_surface.index_of_refraction",
+                            "valueType": "float",
+                            "value": "1.51999998f"
+                        },
+                        {
+                            "valueName": "define_usd_preview_surface.clearcoat",
+                            "valueType": "float",
+                            "value": "0f"
+                        },
+                        {
+                            "valueName": "define_usd_preview_surface.opacity",
+                            "valueType": "float",
+                            "value": "1f"
+                        },
+                        {
+                            "valueName": "define_usd_preview_surface.texture_file_path",
+                            "valueType": "string",
+                            "value": ""
+                        },
+                        {
+                            "valueName": "define_usd_preview_surface.attribute_definitions",
+                            "valueType": "array<Object>",
+                            "value": []
+                        },
+                        {
+                            "valueName": "get_material_path.material_purpose",
+                            "valueType": "BifrostUsd::MaterialPurpose",
+                            "value": "All"
+                        },
+                        {
+                            "valueName": "get_material_path.compute_bound_material",
+                            "valueType": "bool",
+                            "value": "false"
+                        }
+                    ],
+                    "reservedNodeNames": [
+                        {
+                            "name": "input"
+                        },
+                        {
+                            "name": "output"
+                        }
+                    ]
+                },
+                {
+                    "name": "stage_compounds_and_nodedefs",
+                    "uriImported": "file:///load_all_compounds_test00.json",
+                    "metadata": [
+                        {
+                            "metaName": "io_nodes",
+                            "metadata": [
+                                {
+                                    "metaName": "io_inodes",
+                                    "metadata": [
+                                        {
+                                            "metaName": "input",
+                                            "metadata": [
+                                                {
+                                                    "metaName": "DisplayMode",
+                                                    "metaType": "string",
+                                                    "metaValue": "2"
+                                                },
+                                                {
+                                                    "metaName": "LayoutPos",
+                                                    "metaType": "string",
+                                                    "metaValue": "-591 -232"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "metaName": "io_onodes",
+                                    "metadata": [
+                                        {
+                                            "metaName": "output",
+                                            "metadata": [
+                                                {
+                                                    "metaName": "DisplayMode",
+                                                    "metaType": "string",
+                                                    "metaValue": "2"
+                                                },
+                                                {
+                                                    "metaName": "LayoutPos",
+                                                    "metaType": "string",
+                                                    "metaValue": "-351 -232"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "metaName": "_recentNode_",
+                            "metaType": "string",
+                            "metaValue": "BifrostGraph,USD::Stage,set_stage_up_axis"
+                        },
+                        {
+                            "metaName": "_recentNode_",
+                            "metaType": "string",
+                            "metaValue": "BifrostGraph,USD::Stage,set_stage_time_code"
+                        },
+                        {
+                            "metaName": "_recentNode_",
+                            "metaType": "string",
+                            "metaValue": "BifrostGraph,USD::Stage,set_stage_documentation"
+                        },
+                        {
+                            "metaName": "_recentNode_",
+                            "metaType": "string",
+                            "metaValue": "BifrostGraph,USD::Stage,set_stage_custom_layer_data"
+                        },
+                        {
+                            "metaName": "_recentNode_",
+                            "metaType": "string",
+                            "metaValue": "BifrostGraph,USD::Stage,set_stage_comment"
+                        },
+                        {
+                            "metaName": "ViewportRect",
+                            "metaType": "string",
+                            "metaValue": "-670.667 -551.05 2275.33 1336.1"
+                        }
+                    ],
+                    "ports": [],
+                    "compoundNodes": [
+                        {
+                            "nodeName": "add_to_stage",
+                            "nodeType": "USD::Stage::add_to_stage",
+                            "fanInPortNames": {
+                                "prim_definitions": []
+                            },
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "-592.366 -69.077"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "create_usd_stage",
+                            "nodeType": "USD::Stage::create_usd_stage",
+                            "fanInPortNames": {
+                                "sublayers": []
+                            },
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "-383.732 -45.8523"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "export_stage_to_file",
+                            "nodeType": "USD::Stage::export_stage_to_file",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "-171 -52"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "export_stage_to_string",
+                            "nodeType": "USD::Stage::export_stage_to_string",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "39 -52"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "get_default_prim",
+                            "nodeType": "USD::Stage::get_default_prim",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "249 -52"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "get_stage_comment",
+                            "nodeType": "USD::Stage::get_stage_comment",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "459 -52"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "get_stage_custom_layer_data",
+                            "nodeType": "USD::Stage::get_stage_custom_layer_data",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "670.366 -75.9077"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "get_stage_documentation",
+                            "nodeType": "USD::Stage::get_stage_documentation",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "879 -52"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "open_stage_from_cache",
+                            "nodeType": "USD::Stage::open_stage_from_cache",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "1089 -52"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "open_stage_from_layer",
+                            "nodeType": "USD::Stage::open_stage_from_layer",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "1299 -52"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "open_usd_stage",
+                            "nodeType": "USD::Stage::open_usd_stage",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "-591 218"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "save_usd_stage",
+                            "nodeType": "USD::Stage::save_usd_stage",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "-382.366 230.295"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "send_stage_to_cache",
+                            "nodeType": "USD::Stage::send_stage_to_cache",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "-171 218"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "set_edit_layer",
+                            "nodeType": "USD::Stage::set_edit_layer",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "39 218"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "set_stage_comment",
+                            "nodeType": "USD::Stage::set_stage_comment",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "249 218"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "set_stage_custom_layer_data",
+                            "nodeType": "USD::Stage::set_stage_custom_layer_data",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "456.268 195.458"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "set_stage_documentation",
+                            "nodeType": "USD::Stage::set_stage_documentation",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "669 218"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "set_stage_time_code",
+                            "nodeType": "USD::Stage::set_stage_time_code",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "879 218"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "set_stage_up_axis",
+                            "nodeType": "USD::Stage::set_stage_up_axis",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "1089 218"
+                                }
+                            ]
+                        }
+                    ],
+                    "connections": [],
+                    "values": [
+                        {
+                            "valueName": "add_to_stage.enable",
+                            "valueType": "bool",
+                            "value": "true"
+                        },
+                        {
+                            "valueName": "add_to_stage.prim_definitions",
+                            "valueType": "array<Object>",
+                            "value": []
+                        },
+                        {
+                            "valueName": "add_to_stage.parent_path",
+                            "valueType": "string",
+                            "value": ""
+                        },
+                        {
+                            "valueName": "add_to_stage.layer_index",
+                            "valueType": "int",
+                            "value": "-1L"
+                        },
+                        {
+                            "valueName": "add_to_stage.use_material_name_or_tag",
+                            "valueType": "bool",
+                            "value": "false"
+                        },
+                        {
+                            "valueName": "create_usd_stage.layer",
+                            "valueType": "string",
+                            "value": ""
+                        },
+                        {
+                            "valueName": "create_usd_stage.sublayers",
+                            "valueType": "array<BifrostUsd::Layer>",
+                            "value": []
+                        },
+                        {
+                            "valueName": "create_usd_stage.mask",
+                            "valueType": "array<string>",
+                            "value": []
+                        },
+                        {
+                            "valueName": "create_usd_stage.load",
+                            "valueType": "BifrostUsd::InitialLoadSet",
+                            "value": "LoadAll"
+                        },
+                        {
+                            "valueName": "create_usd_stage.layer_index",
+                            "valueType": "int",
+                            "value": "-1L"
+                        }
+                    ],
+                    "reservedNodeNames": [
+                        {
+                            "name": "input"
+                        },
+                        {
+                            "name": "output"
+                        }
+                    ]
+                },
+                {
+                    "name": "variantset_compounds_and_nodedefs",
+                    "uriImported": "file:///load_all_compounds_test00.json",
+                    "metadata": [
+                        {
+                            "metaName": "io_nodes",
+                            "metadata": [
+                                {
+                                    "metaName": "io_inodes",
+                                    "metadata": [
+                                        {
+                                            "metaName": "input",
+                                            "metadata": [
+                                                {
+                                                    "metaName": "DisplayMode",
+                                                    "metaType": "string",
+                                                    "metaValue": "2"
+                                                },
+                                                {
+                                                    "metaName": "LayoutPos",
+                                                    "metaType": "string",
+                                                    "metaValue": "-681 -262"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "metaName": "io_onodes",
+                                    "metadata": [
+                                        {
+                                            "metaName": "output",
+                                            "metadata": [
+                                                {
+                                                    "metaName": "DisplayMode",
+                                                    "metaType": "string",
+                                                    "metaValue": "2"
+                                                },
+                                                {
+                                                    "metaName": "LayoutPos",
+                                                    "metaType": "string",
+                                                    "metaValue": "-441 -262"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "metaName": "_recentNode_",
+                            "metaType": "string",
+                            "metaValue": "BifrostGraph,USD::VariantSet,set_variant_selection"
+                        },
+                        {
+                            "metaName": "_recentNode_",
+                            "metaType": "string",
+                            "metaValue": "BifrostGraph,USD::VariantSet,get_variants"
+                        },
+                        {
+                            "metaName": "_recentNode_",
+                            "metaType": "string",
+                            "metaValue": "BifrostGraph,USD::VariantSet,get_variant_sets"
+                        },
+                        {
+                            "metaName": "_recentNode_",
+                            "metaType": "string",
+                            "metaValue": "BifrostGraph,USD::VariantSet,define_usd_variant_set"
+                        },
+                        {
+                            "metaName": "_recentNode_",
+                            "metaType": "string",
+                            "metaValue": "BifrostGraph,USD::VariantSet,add_variant_set"
+                        },
+                        {
+                            "metaName": "ViewportRect",
+                            "metaType": "string",
+                            "metaValue": "-1110 -652 2220.67 1304"
+                        }
+                    ],
+                    "ports": [],
+                    "compoundNodes": [
+                        {
+                            "nodeName": "add_variant",
+                            "nodeType": "USD::VariantSet::add_variant",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "-681 -52"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "add_variant_set",
+                            "nodeType": "USD::VariantSet::add_variant_set",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "-471 -52"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "define_usd_variant_set",
+                            "nodeType": "USD::VariantSet::define_usd_variant_set",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "-261 -52"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "get_variant_sets",
+                            "nodeType": "USD::VariantSet::get_variant_sets",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "-53 -34"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "get_variants",
+                            "nodeType": "USD::VariantSet::get_variants",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "163 -56"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "set_variant_selection",
+                            "nodeType": "USD::VariantSet::set_variant_selection",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "369 -52"
+                                }
+                            ]
+                        }
+                    ],
+                    "connections": [],
+                    "values": [
+                        {
+                            "valueName": "add_variant.set_variant_selection",
+                            "valueType": "bool",
+                            "value": "true"
+                        }
+                    ],
+                    "reservedNodeNames": [
+                        {
+                            "name": "input"
+                        },
+                        {
+                            "name": "output"
+                        }
+                    ]
+                },
+                {
+                    "name": "utils_compounds_and_nodedefs",
+                    "uriImported": "file:///load_all_compounds_test00.json",
+                    "metadata": [
+                        {
+                            "metaName": "io_nodes",
+                            "metadata": [
+                                {
+                                    "metaName": "io_inodes",
+                                    "metadata": [
+                                        {
+                                            "metaName": "input",
+                                            "metadata": [
+                                                {
+                                                    "metaName": "DisplayMode",
+                                                    "metaType": "string",
+                                                    "metaValue": "2"
+                                                },
+                                                {
+                                                    "metaName": "LayoutPos",
+                                                    "metaType": "string",
+                                                    "metaValue": "-651 -262"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "metaName": "io_onodes",
+                                    "metadata": [
+                                        {
+                                            "metaName": "output",
+                                            "metadata": [
+                                                {
+                                                    "metaName": "DisplayMode",
+                                                    "metaType": "string",
+                                                    "metaValue": "2"
+                                                },
+                                                {
+                                                    "metaName": "LayoutPos",
+                                                    "metaType": "string",
+                                                    "metaValue": "-411 -262"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "metaName": "ViewportRect",
+                            "metaType": "string",
+                            "metaValue": "-1110 -652 2220.67 1304"
+                        }
+                    ],
+                    "ports": [],
+                    "compoundNodes": [
+                        {
+                            "nodeName": "create_child_prim_path",
+                            "nodeType": "USD::Utils::create_child_prim_path",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "-651 -52"
+                                }
+                            ]
+                        }
+                    ],
+                    "connections": [],
+                    "values": [
+                        {
+                            "valueName": "create_child_prim_path.parent_path",
+                            "valueType": "string",
+                            "value": ""
+                        },
+                        {
+                            "valueName": "create_child_prim_path.name",
+                            "valueType": "string",
+                            "value": ""
+                        }
+                    ],
+                    "reservedNodeNames": [
+                        {
+                            "name": "input"
+                        },
+                        {
+                            "name": "output"
+                        }
+                    ]
+                },
+                {
+                    "name": "io_compounds_and_nodedefs",
+                    "uriImported": "file:///load_all_compounds_test00.json",
+                    "metadata": [
+                        {
+                            "metaName": "io_nodes",
+                            "metadata": [
+                                {
+                                    "metaName": "io_inodes",
+                                    "metadata": [
+                                        {
+                                            "metaName": "input",
+                                            "metadata": [
+                                                {
+                                                    "metaName": "DisplayMode",
+                                                    "metaType": "string",
+                                                    "metaValue": "2"
+                                                },
+                                                {
+                                                    "metaName": "LayoutPos",
+                                                    "metaType": "string",
+                                                    "metaValue": "-681 -262"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "metaName": "io_onodes",
+                                    "metadata": [
+                                        {
+                                            "metaName": "output",
+                                            "metadata": [
+                                                {
+                                                    "metaName": "DisplayMode",
+                                                    "metaType": "string",
+                                                    "metaValue": "2"
+                                                },
+                                                {
+                                                    "metaName": "LayoutPos",
+                                                    "metaType": "string",
+                                                    "metaValue": "-441 -262"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "metaName": "_recentNode_",
+                            "metaType": "string",
+                            "metaValue": "BifrostGraph,USD::IO,usd_file_path"
+                        },
+                        {
+                            "metaName": "_recentNode_",
+                            "metaType": "string",
+                            "metaValue": "BifrostGraph,USD::IO,read_usd_meshes"
+                        },
+                        {
+                            "metaName": "_recentNode_",
+                            "metaType": "string",
+                            "metaValue": "BifrostGraph,USD::IO,read_usd_curves"
+                        },
+                        {
+                            "metaName": "_recentNode_",
+                            "metaType": "string",
+                            "metaValue": "BifrostGraph,USD::Utils,create_child_prim_path"
+                        },
+                        {
+                            "metaName": "_recentNode_",
+                            "metaType": "string",
+                            "metaValue": "BifrostGraph,USD::VariantSet,add_variant"
+                        },
+                        {
+                            "metaName": "ViewportRect",
+                            "metaType": "string",
+                            "metaValue": "-1110 -652 2220.67 1304"
+                        }
+                    ],
+                    "ports": [],
+                    "compoundNodes": [
+                        {
+                            "nodeName": "read_usd_curves",
+                            "nodeType": "USD::IO::read_usd_curves",
+                            "fanInPortNames": {
+                                "exclude_prefixes": []
+                            },
+                            "terminalStates": [
+                                {
+                                    "name": "Core::Graph::terminal::diagnostic",
+                                    "enabled": "true"
+                                }
+                            ],
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "-681 -52"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "read_usd_meshes",
+                            "nodeType": "USD::IO::read_usd_meshes",
+                            "fanInPortNames": {
+                                "exclude_prefixes": []
+                            },
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "-471 -52"
+                                }
+                            ]
+                        },
+                        {
+                            "nodeName": "usd_file_path",
+                            "nodeType": "USD::IO::usd_file_path",
+                            "metadata": [
+                                {
+                                    "metaName": "DisplayMode",
+                                    "metaType": "string",
+                                    "metaValue": "2"
+                                },
+                                {
+                                    "metaName": "LayoutPos",
+                                    "metaType": "string",
+                                    "metaValue": "-261 -52"
+                                }
+                            ]
+                        }
+                    ],
+                    "connections": [],
+                    "values": [
+                        {
+                            "valueName": "read_usd_curves.prim_path",
+                            "valueType": "string",
+                            "value": "/curves"
+                        },
+                        {
+                            "valueName": "read_usd_curves.exclude_prefixes",
+                            "valueType": "array<string>",
+                            "value": []
+                        },
+                        {
+                            "valueName": "read_usd_curves.frame",
+                            "valueType": "float",
+                            "value": "0f"
+                        }
+                    ],
+                    "reservedNodeNames": [
+                        {
+                            "name": "input"
+                        },
+                        {
+                            "name": "output"
+                        }
+                    ]
+                }
+            ],
+            "compoundNodes": [
+                {
+                    "nodeName": "build_array",
+                    "nodeType": "Core::Array::build_array",
+                    "multiInPortNames": [
+                        "output"
+                    ],
+                    "metadata": [
+                        {
+                            "metaName": "DisplayMode",
+                            "metaType": "string",
+                            "metaValue": "2"
+                        },
+                        {
+                            "metaName": "LayoutPos",
+                            "metaType": "string",
+                            "metaValue": "472 389"
+                        }
+                    ]
+                },
+                {
+                    "nodeName": "value",
+                    "valueType": "string",
+                    "metadata": [
+                        {
+                            "metaName": "DisplayMode",
+                            "metaType": "string",
+                            "metaValue": "2"
+                        },
+                        {
+                            "metaName": "valuenode_defaultvalue",
+                            "metaType": "string",
+                            "metaValue": "0"
+                        },
+                        {
+                            "metaName": "LayoutPos",
+                            "metaType": "string",
+                            "metaValue": "472 149"
+                        }
+                    ]
+                },
+                {
+                    "nodeName": "value1",
+                    "valueType": "string",
+                    "metadata": [
+                        {
+                            "metaName": "DisplayMode",
+                            "metaType": "string",
+                            "metaValue": "2"
+                        },
+                        {
+                            "metaName": "valuenode_defaultvalue",
+                            "metaType": "string",
+                            "metaValue": "0"
+                        },
+                        {
+                            "metaName": "LayoutPos",
+                            "metaType": "string",
+                            "metaValue": "202 389"
+                        }
+                    ]
+                },
+                {
+                    "nodeName": "attribute_compounds_and_nodedefs",
+                    "nodeType": "attribute_compounds_and_nodedefs",
+                    "metadata": [
+                        {
+                            "metaName": "DisplayMode",
+                            "metaType": "string",
+                            "metaValue": "2"
+                        },
+                        {
+                            "metaName": "LayoutPos",
+                            "metaType": "string",
+                            "metaValue": "202 689"
+                        }
+                    ]
+                },
+                {
+                    "nodeName": "prim_compounds_and_nodedefs",
+                    "nodeType": "prim_compounds_and_nodedefs",
+                    "metadata": [
+                        {
+                            "metaName": "DisplayMode",
+                            "metaType": "string",
+                            "metaValue": "2"
+                        },
+                        {
+                            "metaName": "LayoutPos",
+                            "metaType": "string",
+                            "metaValue": "502 686"
+                        }
+                    ]
+                },
+                {
+                    "nodeName": "collection_compounds_and_nodedefs",
+                    "nodeType": "collection_compounds_and_nodedefs",
+                    "metadata": [
+                        {
+                            "metaName": "DisplayMode",
+                            "metaType": "string",
+                            "metaValue": "2"
+                        },
+                        {
+                            "metaName": "LayoutPos",
+                            "metaType": "string",
+                            "metaValue": "802.753 686"
+                        }
+                    ]
+                },
+                {
+                    "nodeName": "layer_compounds_and_nodedefs",
+                    "nodeType": "layer_compounds_and_nodedefs",
+                    "metadata": [
+                        {
+                            "metaName": "DisplayMode",
+                            "metaType": "string",
+                            "metaValue": "2"
+                        },
+                        {
+                            "metaName": "LayoutPos",
+                            "metaType": "string",
+                            "metaValue": "1102 686"
+                        }
+                    ]
+                },
+                {
+                    "nodeName": "shading_compounds_and_nodedefs",
+                    "nodeType": "shading_compounds_and_nodedefs",
+                    "metadata": [
+                        {
+                            "metaName": "DisplayMode",
+                            "metaType": "string",
+                            "metaValue": "2"
+                        },
+                        {
+                            "metaName": "LayoutPos",
+                            "metaType": "string",
+                            "metaValue": "202 896"
+                        }
+                    ]
+                },
+                {
+                    "nodeName": "stage_compounds_and_nodedefs",
+                    "nodeType": "stage_compounds_and_nodedefs",
+                    "metadata": [
+                        {
+                            "metaName": "DisplayMode",
+                            "metaType": "string",
+                            "metaValue": "2"
+                        },
+                        {
+                            "metaName": "LayoutPos",
+                            "metaType": "string",
+                            "metaValue": "502 896"
+                        }
+                    ]
+                },
+                {
+                    "nodeName": "variantset_compounds_and_nodedefs",
+                    "nodeType": "variantset_compounds_and_nodedefs",
+                    "metadata": [
+                        {
+                            "metaName": "LayoutPos",
+                            "metaType": "string",
+                            "metaValue": "802.753 896"
+                        },
+                        {
+                            "metaName": "DisplayMode",
+                            "metaType": "string",
+                            "metaValue": "2"
+                        }
+                    ]
+                },
+                {
+                    "nodeName": "utils_compounds_and_nodedefs",
+                    "nodeType": "utils_compounds_and_nodedefs",
+                    "metadata": [
+                        {
+                            "metaName": "DisplayMode",
+                            "metaType": "string",
+                            "metaValue": "2"
+                        },
+                        {
+                            "metaName": "LayoutPos",
+                            "metaType": "string",
+                            "metaValue": "1102 896"
+                        }
+                    ]
+                },
+                {
+                    "nodeName": "io_compounds_and_nodedefs",
+                    "nodeType": "io_compounds_and_nodedefs",
+                    "metadata": [
+                        {
+                            "metaName": "DisplayMode",
+                            "metaType": "string",
+                            "metaValue": "2"
+                        },
+                        {
+                            "metaName": "LayoutPos",
+                            "metaType": "string",
+                            "metaValue": "193 1106"
+                        }
+                    ]
+                }
+            ],
+            "connections": [
+                {
+                    "source": "build_array.array",
+                    "target": ".failure_msgs"
+                },
+                {
+                    "source": "value.output",
+                    "target": ".test_info"
+                },
+                {
+                    "source": "value1.output",
+                    "target": "build_array.first.output"
+                }
+            ],
+            "values": [
+                {
+                    "valueName": "value.value",
+                    "valueType": "string",
+                    "value": "Load all USD compounds without executing them."
+                },
+                {
+                    "valueName": "value1.value",
+                    "valueType": "string",
+                    "value": ""
+                }
+            ],
+            "reservedNodeNames": [
+                {
+                    "name": "output"
+                },
+                {
+                    "name": "input"
+                }
+            ]
+        }
+    ]
+}

--- a/test/nodedefs/test_graphs.py
+++ b/test/nodedefs/test_graphs.py
@@ -343,6 +343,7 @@ class TestGraphs(unittest.TestCase):
         task_desc_files = [
             # Integration Tests:
             "tasks_landscape_generator.json",
+            "tasks_load_all_compounds.json",
             # IO Tests:
             "tasks_read_usd_curves.json",
             "tasks_read_usd_meshes.json",

--- a/test/taskDescriptions/tasks_load_all_compounds.json
+++ b/test/taskDescriptions/tasks_load_all_compounds.json
@@ -1,0 +1,19 @@
+{
+    "schemaVersion": "1.0.0",
+    "comment": [
+        "Test load_all_compounds_test00 compound.",
+        "Until each Bifrost USD compound has a proper unit test, this simple",
+        "test will at least ensure that all of those compounds are loading",
+        "correctly in Bifrost."
+    ],
+    "options": {
+        "definitionFiles": [
+            "load_all_compounds_test00.json"
+        ],
+        "compound": "USD::Test::Integration::load_all_compounds_test00"
+    },
+    "task": {
+        "type": "single",
+        "name": "Use Default Params"
+    }
+}


### PR DESCRIPTION
At the moment, the test coverage of USD compounds is not as complete as the tests for the C++ operators.
When a USD compound is modified and broken in a way that it does not load anymore, we have no automated test that reports it to us, unless this compound is specifically loaded and executed in one of our existing tests.

**Changes proposed in this pull request**
Adds a simple test that loads all USD compounds, and integrate this test in test_graphs.py.
<img width="1328" alt="load_all_compounds" src="https://user-images.githubusercontent.com/424502/211040893-e48378cb-4f14-4b7c-977c-320a26a91215.png">