### PR TITLE
BIFROST-7955 - Add applied schema nodes

### DIFF
--- a/src/nodedefs/usd_prim_nodedefs.cpp
+++ b/src/nodedefs/usd_prim_nodedefs.cpp
@@ -260,6 +260,38 @@ void USD::Prim::override_prim(BifrostUsd::Stage& stage,
     }
 }
 
+bool USD::Prim::add_applied_schema(BifrostUsd::Stage&   stage,
+                                   const Amino::String& prim_path,
+                                   const Amino::String& applied_schema_name) {
+    if (!stage) return false;
+    try {
+        auto pxr_prim = USDUtils::get_prim_or_throw(prim_path, stage);
+        VariantEditContext ctx(stage);
+        stage.last_modified_prim = pxr_prim.GetPath().GetText();
+        return pxr_prim.AddAppliedSchema(
+            pxr::TfToken(applied_schema_name.c_str()));
+    } catch (std::exception& e) {
+        log_exception("add_applied_schema", e);
+    }
+    return false;
+}
+
+bool USD::Prim::remove_applied_schema(BifrostUsd::Stage&   stage,
+                                   const Amino::String& prim_path,
+                                   const Amino::String& applied_schema_name) {
+    if (!stage) return false;
+    try {
+        auto pxr_prim = USDUtils::get_prim_or_throw(prim_path, stage);
+        VariantEditContext ctx(stage);
+        stage.last_modified_prim = pxr_prim.GetPath().GetText();
+        return pxr_prim.RemoveAppliedSchema(
+            pxr::TfToken(applied_schema_name.c_str()));
+    } catch (std::exception& e) {
+        log_exception("remove_applied_schema", e);
+    }
+    return false;
+}
+
 bool USD::Prim::add_reference_prim(
     BifrostUsd::Stage&                stage,
     const Amino::String&                prim_path,

--- a/src/nodedefs/usd_prim_nodedefs.h
+++ b/src/nodedefs/usd_prim_nodedefs.h
@@ -156,6 +156,46 @@ void override_prim(BifrostUsd::Stage& stage USDPORT_INOUT("out_stage"),
     USDNODE_DOC_ICON("override_prim", "override_prim", "usd.svg");
 
 /// \ingroup Prim
+/// \defgroup add_applied_schema add_applied_schema node
+///
+/// \brief Adds the applied API schema to the prim.
+///
+/// \param [in] stage The USD stage holding the prim.
+/// \param [in] prim_path The path to the prim the schema will be added to.
+/// \param [in] applied_schema_name The applied schema name.
+///             This does not require that the name token refer to
+///              a valid API schema type.
+/// \returns true if the schema is added successfully or if
+///          it is already applied in current edit target.
+USD_NODEDEF_DECL
+bool add_applied_schema(BifrostUsd::Stage& stage USDPORT_INOUT("out_stage"),
+                        const Amino::String&     prim_path,
+                        const Amino::String&     applied_schema_name)
+    USDNODE_DOC_ICON_X("add_applied_schema",
+                       "add_applied_schema",
+                       "usd.svg",
+                       "outName=success");
+
+/// \ingroup Prim
+/// \defgroup remove_applied_schema remove_applied_schema node
+///
+/// \brief Removes the applied API schema from the prim.
+///
+/// \param [in] stage The USD stage holding the prim.
+/// \param [in] prim_path The path to the prim the schema will be removed from.
+/// \param [in] applied_schema_name The applied schema name.
+/// \returns true if the schema is removed successfully or if
+///               it is already deleted in current edit target.
+USD_NODEDEF_DECL
+bool remove_applied_schema(BifrostUsd::Stage& stage USDPORT_INOUT("out_stage"),
+                           const Amino::String&     prim_path,
+                           const Amino::String&     applied_schema_name)
+    USDNODE_DOC_ICON_X("remove_applied_schema",
+                       "remove_applied_schema",
+                       "usd.svg",
+                       "outName=success");
+
+/// \ingroup Prim
 /// \defgroup add_reference_prim add_reference_prim node
 ///
 /// \brief Adds a prim reference in the given stage.

--- a/test/nodedefs/testPrimNodeDefs.cpp
+++ b/test/nodedefs/testPrimNodeDefs.cpp
@@ -165,6 +165,40 @@ TEST(PrimNodeDefs, create_class_prim) {
     ASSERT_EQ(prim.GetSpecifier(), pxr::SdfSpecifierClass);
 }
 
+TEST(PrimNodeDefs, add_applied_schema) {
+    BifrostUsd::Stage stage;
+    auto              primPath = pxr::SdfPath("/S");
+    auto              prim     = stage->DefinePrim(primPath);
+
+    ASSERT_EQ(prim.GetAppliedSchemas().size(), 0);
+
+    Amino::String appliedSchemaName = "SkelBindingAPI";
+
+    bool success = USD::Prim::add_applied_schema(stage, primPath.GetText(),
+                                                 appliedSchemaName);
+    EXPECT_TRUE(success);
+
+    prim = stage->GetPrimAtPath(primPath);
+    EXPECT_EQ(prim.GetAppliedSchemas().size(), 1);
+    EXPECT_EQ(prim.GetAppliedSchemas()[0], pxr::TfToken{"SkelBindingAPI"});
+}
+
+TEST(PrimNodeDefs, remove_applied_schema) {
+    BifrostUsd::Stage stage;
+    auto              primPath          = pxr::SdfPath("/S");
+    auto              prim              = stage->DefinePrim(primPath);
+    Amino::String     appliedSchemaName = "SkelBindingAPI";
+    ASSERT_TRUE(prim.AddAppliedSchema(pxr::TfToken{appliedSchemaName.c_str()}));
+    ASSERT_EQ(prim.GetAppliedSchemas().size(), 1);
+
+    bool success = USD::Prim::remove_applied_schema(stage, primPath.GetText(),
+                                                    appliedSchemaName);
+    EXPECT_TRUE(success);
+
+    prim = stage->GetPrimAtPath(primPath);
+    EXPECT_EQ(prim.GetAppliedSchemas().size(), 0);
+}
+
 TEST(PrimNodeDefs, add_reference_prim) {
     BifrostUsd::Stage stage;
     auto                primPath = pxr::SdfPath("/a");


### PR DESCRIPTION
**Changes proposed in this pull request**

- _add_applied_schema_: A new C++ operator to add the applied API schema name to the apiSchema metadata of the prim.
- _remove_applied_schema_: A new C++ operator to remove the applied API schema name from the apiSchema metadata of the prim.