### PR TITLE
BIFROST-8065 - add support to build for desired binary architecture on osx

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ You must provide the following variables to the cmake command:
 * MAYA_RUNTIME_LOCATION : (optional) The full path to the root directory of your Maya development installation that contains, among others, the `bin`, `include` and `lib` subdirectories.
 * BIFUSD_OSX_ACTIVE_SDK : (optional) Can be set to choose a specific macOS SDK. If not set, the currently available SDK will be used.
 * BIFUSD_OSX_MIN_OS : (optional) Can be set to choose the minimum macOS deployement target. If not set, macOS 11.0 will be used.
+* BIFUSD_OSX_BINARY_ARCH : (optional) Can be set to choose the target architecture to build on macOS. Acceptable values are `x64` (Intel CPU), `arm64` (Apple M1 CPU), `ub2` (Universal Binary 2 - both x64 and arm64) and empty (default) (host system's processor).
 
 __Python 3 version is assumed.__
 

--- a/cmake/bifusd/compiler_Clang.cmake
+++ b/cmake/bifusd/compiler_Clang.cmake
@@ -1,6 +1,6 @@
 #-
 #*****************************************************************************
-# Copyright 2022 Autodesk, Inc.
+# Copyright 2023 Autodesk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -148,15 +148,19 @@ else()
 endif()
 
 # Use -O3 instead of -O2 to match the release build default.
+if (NOT "${BIFUSD_OSX_BINARY_ARCH}" STREQUAL "arm64")
+    set(x86_64_only_options "-msse4.2")
+endif()
 set(cxx_flags_release
     -g
     -O3
-    -msse4.2
+    ${x86_64_only_options}
     ${cxx_warning_flags}
 )
 
-# Setting target architecture on non Universal Binary 2 build.
-if (NOT BIFUSD_OSX_BUILD_UB2)
+# On OSX, we pass this only if we are building for X64.
+# on Other platforms we always generate for westmere.
+if ((NOT BIFUSD_IS_OSX) OR ("${BIFUSD_OSX_BINARY_ARCH}" STREQUAL "x64"))
     list(APPEND cxx_flags_release -march=westmere)
 endif()
 

--- a/cmake/bifusd/compiler_GNU.cmake
+++ b/cmake/bifusd/compiler_GNU.cmake
@@ -1,6 +1,6 @@
 #-
 #*****************************************************************************
-# Copyright 2022 Autodesk, Inc.
+# Copyright 2023 Autodesk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -70,15 +70,20 @@ endif()
 
 
 # Use -O3 instead of -O2 to match the release build default.
+if (NOT "${BIFUSD_OSX_BINARY_ARCH}" STREQUAL "arm64")
+    set(x86_64_only_options "-msse4.2")
+endif()
 set(cxx_flags_release
     -g
     -O3
-    -msse4.2
+    ${x86_64_only_options}
     ${cxx_warning_flags}
 )
-# Setting target architecture on non Universal Binary 2 build. 
-if (NOT BIFUSD_OSX_BUILD_UB2)
-    list(APPEND cxx_flags_release -march=westmere)
+
+# On OSX, we pass this only if we are building for X64.
+# on Other platforms we always generate for westmere.
+if ((NOT BIFUSD_IS_OSX) OR ("${BIFUSD_OSX_BINARY_ARCH}" STREQUAL "x64"))
+     list(APPEND cxx_flags_release -march=westmere)
 endif()
 
 string(REPLACE ";" " " cxx_flags_relwithasserts "${cxx_flags_release}")

--- a/cmake/bifusd/platform_sdk_Darwin.cmake
+++ b/cmake/bifusd/platform_sdk_Darwin.cmake
@@ -1,6 +1,6 @@
 #-
 #*****************************************************************************
-# Copyright 2022 Autodesk, Inc.
+# Copyright 2023 Autodesk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -30,10 +30,23 @@ if( nb_languages )
 endif()
 
 # Setup OSX specific flags.
-if (BIFUSD_OSX_BUILD_UB2)
+# If binary arch not set explicitaly use same as system
+if (NOT BIFUSD_OSX_BINARY_ARCH)
+    if ("${CMAKE_HOST_SYSTEM_PROCESSOR}" STREQUAL "arm64")
+        set(BIFUSD_OSX_BINARY_ARCH "arm64")
+    else()
+        set(BIFUSD_OSX_BINARY_ARCH "x64")
+    endif()
+endif()
+
+if ("${BIFUSD_OSX_BINARY_ARCH}" STREQUAL "ub2")
     bifusd_reset_cache_entry(CMAKE_OSX_ARCHITECTURES "x86_64;arm64")
-else()
+elseif ("${BIFUSD_OSX_BINARY_ARCH}" STREQUAL "x64")
     bifusd_reset_cache_entry(CMAKE_OSX_ARCHITECTURES "x86_64")
+elseif ("${BIFUSD_OSX_BINARY_ARCH}" STREQUAL "arm64")
+    bifusd_reset_cache_entry(CMAKE_OSX_ARCHITECTURES "arm64")
+else()
+    message(FATAL_ERROR "Binary architecture ${BIFUSD_OSX_BINARY_ARCH} not supported.")
 endif()
 
 # Set target min OS - will be adjusted.


### PR DESCRIPTION
BIFROST-8065 - add support to build for desired binary architecture on osx