### PR TITLE
Relative reference and UI improvements

### DIFF
--- a/src/nodedefs/compounds/build_prim_from_definition.json
+++ b/src/nodedefs/compounds/build_prim_from_definition.json
@@ -73,6 +73,11 @@
                                                     "metaName": "prim_def"
                                                 }
                                             ]
+                                        },
+                                        {
+                                            "metaName": "zValue",
+                                            "metaType": "string",
+                                            "metaValue": "34.000000"
                                         }
                                     ]
                                 }
@@ -90,6 +95,11 @@
                                             "metaValue": "2"
                                         },
                                         {
+                                            "metaName": "LayoutPos",
+                                            "metaType": "string",
+                                            "metaValue": "1230 244"
+                                        },
+                                        {
                                             "metaName": "io_ports",
                                             "metadata": [
                                                 {
@@ -98,9 +108,9 @@
                                             ]
                                         },
                                         {
-                                            "metaName": "LayoutPos",
+                                            "metaName": "zValue",
                                             "metaType": "string",
-                                            "metaValue": "1230 244"
+                                            "metaValue": "35.000000"
                                         }
                                     ]
                                 }
@@ -111,7 +121,7 @@
                 {
                     "metaName": "ViewportRect",
                     "metaType": "string",
-                    "metaValue": "-70 -313.372 1606.37 1092.14"
+                    "metaValue": "-70 -516.799 1606 1499.6"
                 },
                 {
                     "metaName": "DisplayMode",
@@ -121,7 +131,12 @@
                 {
                     "metaName": "LayoutPos",
                     "metaType": "string",
-                    "metaValue": "311.515 43.4873"
+                    "metaValue": "-46.0266 285.483"
+                },
+                {
+                    "metaName": "zValue",
+                    "metaType": "string",
+                    "metaValue": "52.000000"
                 }
             ],
             "ports": [
@@ -148,11 +163,6 @@
                     "name": "add_arcs",
                     "uriImported": "file:///build_prim_from_definition.json",
                     "metadata": [
-                        {
-                            "metaName": "ViewportRect",
-                            "metaType": "string",
-                            "metaValue": "-70 -183.764 1301 884.527"
-                        },
                         {
                             "metaName": "io_nodes",
                             "metadata": [
@@ -182,6 +192,11 @@
                                                             "metaName": "prim_def"
                                                         }
                                                     ]
+                                                },
+                                                {
+                                                    "metaName": "zValue",
+                                                    "metaType": "string",
+                                                    "metaValue": "34.000000"
                                                 }
                                             ]
                                         }
@@ -210,12 +225,22 @@
                                                             "metaName": "out_stage"
                                                         }
                                                     ]
+                                                },
+                                                {
+                                                    "metaName": "zValue",
+                                                    "metaType": "string",
+                                                    "metaValue": "35.000000"
                                                 }
                                             ]
                                         }
                                     ]
                                 }
                             ]
+                        },
+                        {
+                            "metaName": "ViewportRect",
+                            "metaType": "string",
+                            "metaValue": "-70 -348.903 1301 1214.81"
                         }
                     ],
                     "ports": [
@@ -239,11 +264,6 @@
                             "name": "create_arcs",
                             "uriImported": "file:///build_prim_from_definition.json",
                             "metadata": [
-                                {
-                                    "metaName": "ViewportRect",
-                                    "metaType": "string",
-                                    "metaValue": "-70 -196.264 1301 884.527"
-                                },
                                 {
                                     "metaName": "io_nodes",
                                     "metadata": [
@@ -273,6 +293,11 @@
                                                                     "metaName": "value"
                                                                 }
                                                             ]
+                                                        },
+                                                        {
+                                                            "metaName": "zValue",
+                                                            "metaType": "string",
+                                                            "metaValue": "34.000000"
                                                         }
                                                     ]
                                                 }
@@ -301,12 +326,22 @@
                                                                     "metaName": "out_stage"
                                                                 }
                                                             ]
+                                                        },
+                                                        {
+                                                            "metaName": "zValue",
+                                                            "metaType": "string",
+                                                            "metaValue": "35.000000"
                                                         }
                                                     ]
                                                 }
                                             ]
                                         }
                                     ]
+                                },
+                                {
+                                    "metaName": "ViewportRect",
+                                    "metaType": "string",
+                                    "metaValue": "-70 -361.403 1301 1214.81"
                                 }
                             ],
                             "ports": [
@@ -372,11 +407,6 @@
                                             "metaValue": "BifrostGraph,USD::Utils,populate_stage"
                                         },
                                         {
-                                            "metaName": "ViewportRect",
-                                            "metaType": "string",
-                                            "metaValue": "-514.59 -117 2740.18 1863"
-                                        },
-                                        {
                                             "metaName": "io_nodes",
                                             "metadata": [
                                                 {
@@ -408,6 +438,11 @@
                                                                             "metaName": "value"
                                                                         }
                                                                     ]
+                                                                },
+                                                                {
+                                                                    "metaName": "zValue",
+                                                                    "metaType": "string",
+                                                                    "metaValue": "47.000000"
                                                                 }
                                                             ]
                                                         }
@@ -436,12 +471,22 @@
                                                                             "metaName": "stage1"
                                                                         }
                                                                     ]
+                                                                },
+                                                                {
+                                                                    "metaName": "zValue",
+                                                                    "metaType": "string",
+                                                                    "metaValue": "48.000000"
                                                                 }
                                                             ]
                                                         }
                                                     ]
                                                 }
                                             ]
+                                        },
+                                        {
+                                            "metaName": "ViewportRect",
+                                            "metaType": "string",
+                                            "metaValue": "-251.73 35.5691 1972.52 1841.83"
                                         }
                                     ],
                                     "ports": [
@@ -939,6 +984,11 @@
                                                     "metaName": "LayoutPos",
                                                     "metaType": "string",
                                                     "metaValue": "315.309 -77.1673"
+                                                },
+                                                {
+                                                    "metaName": "zValue",
+                                                    "metaType": "string",
+                                                    "metaValue": "31.000000"
                                                 }
                                             ]
                                         },
@@ -955,6 +1005,11 @@
                                                     "metaName": "LayoutPos",
                                                     "metaType": "string",
                                                     "metaValue": "323.83 743.174"
+                                                },
+                                                {
+                                                    "metaName": "zValue",
+                                                    "metaType": "string",
+                                                    "metaValue": "32.000000"
                                                 }
                                             ]
                                         },
@@ -971,6 +1026,11 @@
                                                     "metaName": "LayoutPos",
                                                     "metaType": "string",
                                                     "metaValue": "1230 252"
+                                                },
+                                                {
+                                                    "metaName": "zValue",
+                                                    "metaType": "string",
+                                                    "metaValue": "33.000000"
                                                 }
                                             ]
                                         },
@@ -987,6 +1047,11 @@
                                                     "metaName": "LayoutPos",
                                                     "metaType": "string",
                                                     "metaValue": "315 179.991"
+                                                },
+                                                {
+                                                    "metaName": "zValue",
+                                                    "metaType": "string",
+                                                    "metaValue": "34.000000"
                                                 }
                                             ]
                                         },
@@ -1003,6 +1068,11 @@
                                                     "metaName": "LayoutPos",
                                                     "metaType": "string",
                                                     "metaValue": "1535 244"
+                                                },
+                                                {
+                                                    "metaName": "zValue",
+                                                    "metaType": "string",
+                                                    "metaValue": "35.000000"
                                                 }
                                             ]
                                         },
@@ -1019,6 +1089,11 @@
                                                     "metaName": "LayoutPos",
                                                     "metaType": "string",
                                                     "metaValue": "925 630"
+                                                },
+                                                {
+                                                    "metaName": "zValue",
+                                                    "metaType": "string",
+                                                    "metaValue": "36.000000"
                                                 }
                                             ]
                                         },
@@ -1035,6 +1110,11 @@
                                                     "metaName": "LayoutPos",
                                                     "metaType": "string",
                                                     "metaValue": "1230 9"
+                                                },
+                                                {
+                                                    "metaName": "zValue",
+                                                    "metaType": "string",
+                                                    "metaValue": "37.000000"
                                                 }
                                             ]
                                         },
@@ -1051,6 +1131,11 @@
                                                     "metaName": "LayoutPos",
                                                     "metaType": "string",
                                                     "metaValue": "647.429 1142.97"
+                                                },
+                                                {
+                                                    "metaName": "zValue",
+                                                    "metaType": "string",
+                                                    "metaValue": "38.000000"
                                                 }
                                             ]
                                         },
@@ -1067,6 +1152,11 @@
                                                     "metaName": "LayoutPos",
                                                     "metaType": "string",
                                                     "metaValue": "628.83 1433.52"
+                                                },
+                                                {
+                                                    "metaName": "zValue",
+                                                    "metaType": "string",
+                                                    "metaValue": "39.000000"
                                                 }
                                             ]
                                         },
@@ -1083,6 +1173,11 @@
                                                     "metaName": "LayoutPos",
                                                     "metaType": "string",
                                                     "metaValue": "663.828 314.16"
+                                                },
+                                                {
+                                                    "metaName": "zValue",
+                                                    "metaType": "string",
+                                                    "metaValue": "40.000000"
                                                 }
                                             ]
                                         },
@@ -1099,6 +1194,11 @@
                                                     "metaName": "LayoutPos",
                                                     "metaType": "string",
                                                     "metaValue": "1293.58 615"
+                                                },
+                                                {
+                                                    "metaName": "zValue",
+                                                    "metaType": "string",
+                                                    "metaValue": "41.000000"
                                                 }
                                             ]
                                         },
@@ -1115,6 +1215,11 @@
                                                     "metaName": "LayoutPos",
                                                     "metaType": "string",
                                                     "metaValue": "616.468 880.092"
+                                                },
+                                                {
+                                                    "metaName": "zValue",
+                                                    "metaType": "string",
+                                                    "metaValue": "42.000000"
                                                 }
                                             ]
                                         },
@@ -1131,6 +1236,11 @@
                                                     "metaName": "LayoutPos",
                                                     "metaType": "string",
                                                     "metaValue": "925 993"
+                                                },
+                                                {
+                                                    "metaName": "zValue",
+                                                    "metaType": "string",
+                                                    "metaValue": "43.000000"
                                                 }
                                             ]
                                         },
@@ -1147,6 +1257,11 @@
                                                     "metaName": "LayoutPos",
                                                     "metaType": "string",
                                                     "metaValue": "292.262 488.559"
+                                                },
+                                                {
+                                                    "metaName": "zValue",
+                                                    "metaType": "string",
+                                                    "metaValue": "44.000000"
                                                 }
                                             ]
                                         },
@@ -1163,6 +1278,11 @@
                                                     "metaName": "LayoutPos",
                                                     "metaType": "string",
                                                     "metaValue": "305.422 970.511"
+                                                },
+                                                {
+                                                    "metaName": "zValue",
+                                                    "metaType": "string",
+                                                    "metaValue": "45.000000"
                                                 }
                                             ]
                                         },
@@ -1179,6 +1299,32 @@
                                                     "metaName": "LayoutPos",
                                                     "metaType": "string",
                                                     "metaValue": "293.351 1219.98"
+                                                },
+                                                {
+                                                    "metaName": "zValue",
+                                                    "metaType": "string",
+                                                    "metaValue": "49.000000"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "nodeName": "get_property9",
+                                            "nodeType": "Core::Object::get_property",
+                                            "metadata": [
+                                                {
+                                                    "metaName": "DisplayMode",
+                                                    "metaType": "string",
+                                                    "metaValue": "2"
+                                                },
+                                                {
+                                                    "metaName": "zValue",
+                                                    "metaType": "string",
+                                                    "metaValue": "53.000000"
+                                                },
+                                                {
+                                                    "metaName": "LayoutPos",
+                                                    "metaType": "string",
+                                                    "metaValue": "290.842 1493.23"
                                                 }
                                             ]
                                         }
@@ -1347,6 +1493,18 @@
                                         {
                                             "source": ".value",
                                             "target": "get_property8.object"
+                                        },
+                                        {
+                                            "source": ".value",
+                                            "target": "get_property9.object"
+                                        },
+                                        {
+                                            "source": "get_property9.value",
+                                            "target": "add_payload_prim.anchor_path"
+                                        },
+                                        {
+                                            "source": "get_property9.value",
+                                            "target": "add_reference_prim.anchor_path"
                                         }
                                     ],
                                     "values": [
@@ -1459,6 +1617,16 @@
                                             "valueName": "get_property8.key",
                                             "valueType": "string",
                                             "value": "layer_position"
+                                        },
+                                        {
+                                            "valueName": "get_property9.default_and_type",
+                                            "valueType": "string",
+                                            "value": ""
+                                        },
+                                        {
+                                            "valueName": "get_property9.key",
+                                            "valueType": "string",
+                                            "value": "anchor_path"
                                         }
                                     ],
                                     "reservedNodeNames": [
@@ -1494,6 +1662,11 @@
                                             "metaName": "LayoutPos",
                                             "metaType": "string",
                                             "metaValue": "315 258"
+                                        },
+                                        {
+                                            "metaName": "zValue",
+                                            "metaType": "string",
+                                            "metaValue": "31.000000"
                                         }
                                     ]
                                 },
@@ -1510,6 +1683,11 @@
                                             "metaName": "LayoutPos",
                                             "metaType": "string",
                                             "metaValue": "620 10"
+                                        },
+                                        {
+                                            "metaName": "zValue",
+                                            "metaType": "string",
+                                            "metaValue": "36.000000"
                                         }
                                     ]
                                 },
@@ -1526,6 +1704,11 @@
                                             "metaName": "LayoutPos",
                                             "metaType": "string",
                                             "metaValue": "315 15"
+                                        },
+                                        {
+                                            "metaName": "zValue",
+                                            "metaType": "string",
+                                            "metaValue": "33.000000"
                                         }
                                     ]
                                 }
@@ -1773,6 +1956,11 @@
                                     "metaName": "LayoutPos",
                                     "metaType": "string",
                                     "metaValue": "315 253"
+                                },
+                                {
+                                    "metaName": "zValue",
+                                    "metaType": "string",
+                                    "metaValue": "36.000000"
                                 }
                             ]
                         },
@@ -1789,6 +1977,11 @@
                                     "metaName": "LayoutPos",
                                     "metaType": "string",
                                     "metaValue": "315 10"
+                                },
+                                {
+                                    "metaName": "zValue",
+                                    "metaType": "string",
+                                    "metaValue": "32.000000"
                                 }
                             ]
                         },
@@ -1805,6 +1998,11 @@
                                     "metaName": "LayoutPos",
                                     "metaType": "string",
                                     "metaValue": "620 215"
+                                },
+                                {
+                                    "metaName": "zValue",
+                                    "metaType": "string",
+                                    "metaValue": "33.000000"
                                 }
                             ]
                         }
@@ -8952,6 +9150,11 @@
                             "metaName": "LayoutPos",
                             "metaType": "string",
                             "metaValue": "925 208"
+                        },
+                        {
+                            "metaName": "zValue",
+                            "metaType": "string",
+                            "metaValue": "36.000000"
                         }
                     ]
                 },
@@ -8968,6 +9171,11 @@
                             "metaName": "LayoutPos",
                             "metaType": "string",
                             "metaValue": "315 10"
+                        },
+                        {
+                            "metaName": "zValue",
+                            "metaType": "string",
+                            "metaValue": "32.000000"
                         }
                     ]
                 },
@@ -8984,6 +9192,11 @@
                             "metaName": "LayoutPos",
                             "metaType": "string",
                             "metaValue": "620 86"
+                        },
+                        {
+                            "metaName": "zValue",
+                            "metaType": "string",
+                            "metaValue": "33.000000"
                         }
                     ]
                 }

--- a/src/nodedefs/compounds/define_usd_reference.json
+++ b/src/nodedefs/compounds/define_usd_reference.json
@@ -61,8 +61,16 @@
                                                 },
                                                 {
                                                     "metaName": "position"
+                                                },
+                                                {
+                                                    "metaName": "anchor_path"
                                                 }
                                             ]
+                                        },
+                                        {
+                                            "metaName": "zValue",
+                                            "metaType": "string",
+                                            "metaValue": "38.000000"
                                         }
                                     ]
                                 }
@@ -80,17 +88,22 @@
                                             "metaValue": "2"
                                         },
                                         {
-                                            "metaName": "LayoutPos",
-                                            "metaType": "string",
-                                            "metaValue": "2450 490"
-                                        },
-                                        {
                                             "metaName": "io_ports",
                                             "metadata": [
                                                 {
                                                     "metaName": "reference_definitions"
                                                 }
                                             ]
+                                        },
+                                        {
+                                            "metaName": "LayoutPos",
+                                            "metaType": "string",
+                                            "metaValue": "2683.74 545.279"
+                                        },
+                                        {
+                                            "metaName": "zValue",
+                                            "metaType": "string",
+                                            "metaValue": "40.000000"
                                         }
                                     ]
                                 }
@@ -114,6 +127,21 @@
                     ]
                 },
                 {
+                    "metaName": "icon",
+                    "metaType": "string",
+                    "metaValue": "../icons/usd.svg"
+                },
+                {
+                    "metaName": "_recentNode_",
+                    "metaType": "string",
+                    "metaValue": "BifrostGraph,Core::Object,set_property"
+                },
+                {
+                    "metaName": "_recentNode_",
+                    "metaType": "string",
+                    "metaValue": "BifrostGraph,USD::Prim,add_reference_prim"
+                },
+                {
                     "metaName": "_recentNode_",
                     "metaType": "string",
                     "metaValue": "BifrostGraph,Core::Logic,if"
@@ -129,34 +157,24 @@
                     "metaValue": "BifrostGraph,USD::Prim,get_prim_path"
                 },
                 {
-                    "metaName": "_recentNode_",
-                    "metaType": "string",
-                    "metaValue": "BifrostGraph,Core::Array,first_in_array"
-                },
-                {
-                    "metaName": "_recentNode_",
-                    "metaType": "string",
-                    "metaValue": "BifrostGraph,USD::Prim,get_prim_children"
-                },
-                {
-                    "metaName": "icon",
-                    "metaType": "string",
-                    "metaValue": "../icons/usd.svg"
-                },
-                {
                     "metaName": "ViewportRect",
                     "metaType": "string",
-                    "metaValue": "-70 -577.674 2826 1921.35"
-                },
-                {
-                    "metaName": "LayoutPos",
-                    "metaType": "string",
-                    "metaValue": "-621.392 78.4293"
+                    "metaValue": "-70 -1016.13 3060 2857.27"
                 },
                 {
                     "metaName": "DisplayMode",
                     "metaType": "string",
                     "metaValue": "2"
+                },
+                {
+                    "metaName": "LayoutPos",
+                    "metaType": "string",
+                    "metaValue": "-98.5 -109"
+                },
+                {
+                    "metaName": "zValue",
+                    "metaType": "string",
+                    "metaValue": "35.000000"
                 }
             ],
             "ports": [
@@ -213,6 +231,24 @@
                     "portDirection": "input",
                     "portType": "BifrostUsd::UsdListPosition",
                     "portDefault": "UsdListPositionFrontOfPrependList"
+                },
+                {
+                    "portName": "anchor_path",
+                    "portDirection": "input",
+                    "portType": "string",
+                    "portDefault": "",
+                    "metadata": [
+                        {
+                            "metaName": "UIWidget",
+                            "metaType": "string",
+                            "metaValue": "FileBrowserWidget"
+                        },
+                        {
+                            "metaName": "UIWidgetProp",
+                            "metaType": "string",
+                            "metaValue": "browserType=folder"
+                        }
+                    ]
                 }
             ],
             "compounds": [
@@ -688,6 +724,11 @@
                             "metaName": "LayoutPos",
                             "metaType": "string",
                             "metaValue": "315 10"
+                        },
+                        {
+                            "metaName": "zValue",
+                            "metaType": "string",
+                            "metaValue": "31.000000"
                         }
                     ]
                 },
@@ -704,6 +745,11 @@
                             "metaName": "LayoutPos",
                             "metaType": "string",
                             "metaValue": "620 147"
+                        },
+                        {
+                            "metaName": "zValue",
+                            "metaType": "string",
+                            "metaValue": "32.000000"
                         }
                     ]
                 },
@@ -720,6 +766,11 @@
                             "metaName": "LayoutPos",
                             "metaType": "string",
                             "metaValue": "925 223"
+                        },
+                        {
+                            "metaName": "zValue",
+                            "metaType": "string",
+                            "metaValue": "33.000000"
                         }
                     ]
                 },
@@ -736,6 +787,11 @@
                             "metaName": "LayoutPos",
                             "metaType": "string",
                             "metaValue": "1230 273"
+                        },
+                        {
+                            "metaName": "zValue",
+                            "metaType": "string",
+                            "metaValue": "34.000000"
                         }
                     ]
                 },
@@ -752,6 +808,11 @@
                             "metaName": "LayoutPos",
                             "metaType": "string",
                             "metaValue": "1535 332"
+                        },
+                        {
+                            "metaName": "zValue",
+                            "metaType": "string",
+                            "metaValue": "35.000000"
                         }
                     ]
                 },
@@ -768,6 +829,11 @@
                             "metaName": "LayoutPos",
                             "metaType": "string",
                             "metaValue": "1840 392"
+                        },
+                        {
+                            "metaName": "zValue",
+                            "metaType": "string",
+                            "metaValue": "36.000000"
                         }
                     ]
                 },
@@ -784,6 +850,11 @@
                             "metaName": "LayoutPos",
                             "metaType": "string",
                             "metaValue": "315 253"
+                        },
+                        {
+                            "metaName": "zValue",
+                            "metaType": "string",
+                            "metaValue": "37.000000"
                         }
                     ]
                 },
@@ -799,7 +870,33 @@
                         {
                             "metaName": "LayoutPos",
                             "metaType": "string",
-                            "metaValue": "2145 490"
+                            "metaValue": "2084.46 495.265"
+                        },
+                        {
+                            "metaName": "zValue",
+                            "metaType": "string",
+                            "metaValue": "39.000000"
+                        }
+                    ]
+                },
+                {
+                    "nodeName": "set_property7",
+                    "nodeType": "Core::Object::set_property",
+                    "metadata": [
+                        {
+                            "metaName": "DisplayMode",
+                            "metaType": "string",
+                            "metaValue": "2"
+                        },
+                        {
+                            "metaName": "LayoutPos",
+                            "metaType": "string",
+                            "metaValue": "2352.88 591.223"
+                        },
+                        {
+                            "metaName": "zValue",
+                            "metaType": "string",
+                            "metaValue": "42.000000"
                         }
                     ]
                 }
@@ -854,10 +951,6 @@
                     "target": "set_property6.object"
                 },
                 {
-                    "source": "set_property6.out_object",
-                    "target": ".reference_definitions"
-                },
-                {
                     "source": ".relative_prim_path",
                     "target": "set_property6.value"
                 },
@@ -868,6 +961,18 @@
                 {
                     "source": ".layer",
                     "target": "resolve_prim_path.layer"
+                },
+                {
+                    "source": ".anchor_path",
+                    "target": "set_property7.value"
+                },
+                {
+                    "source": "set_property6.out_object",
+                    "target": "set_property7.object"
+                },
+                {
+                    "source": "set_property7.out_object",
+                    "target": ".reference_definitions"
                 }
             ],
             "values": [
@@ -945,6 +1050,16 @@
                     "valueName": "set_property6.value",
                     "valueType": "bool",
                     "value": "false"
+                },
+                {
+                    "valueName": "set_property7.key",
+                    "valueType": "string",
+                    "value": "anchor_path"
+                },
+                {
+                    "valueName": "set_property7.value",
+                    "valueType": "string",
+                    "value": ""
                 }
             ],
             "reservedNodeNames": [

--- a/src/nodedefs/compounds/define_usd_reference_from_file.json
+++ b/src/nodedefs/compounds/define_usd_reference_from_file.json
@@ -12,12 +12,13 @@
     "compounds": [
         {
             "name": "USD::Prim::define_usd_reference_from_file",
+            "uriImported": "file:///define_usd_reference_from_file.json",
             "metadata": [
                 {
                     "metaName": "documentation",
                     "metaType": "string",
                     "metaValue": "../docs/${language}/define_usd_reference_from_file.md"
-                },                
+                },
                 {
                     "metaName": "io_nodes",
                     "metadata": [
@@ -31,6 +32,16 @@
                                             "metaName": "DisplayMode",
                                             "metaType": "string",
                                             "metaValue": "2"
+                                        },
+                                        {
+                                            "metaName": "LayoutPos",
+                                            "metaType": "string",
+                                            "metaValue": "10 174"
+                                        },
+                                        {
+                                            "metaName": "zValue",
+                                            "metaType": "string",
+                                            "metaValue": "33.000000"
                                         },
                                         {
                                             "metaName": "io_ports",
@@ -52,13 +63,11 @@
                                                 },
                                                 {
                                                     "metaName": "position"
+                                                },
+                                                {
+                                                    "metaName": "anchor_path"
                                                 }
                                             ]
-                                        },
-                                        {
-                                            "metaName": "LayoutPos",
-                                            "metaType": "string",
-                                            "metaValue": "10 174"
                                         }
                                     ]
                                 }
@@ -71,14 +80,6 @@
                                     "metaName": "output",
                                     "metadata": [
                                         {
-                                            "metaName": "io_ports",
-                                            "metadata": [
-                                                {
-                                                    "metaName": "reference_definitions"
-                                                }
-                                            ]
-                                        },
-                                        {
                                             "metaName": "DisplayMode",
                                             "metaType": "string",
                                             "metaValue": "2"
@@ -87,6 +88,19 @@
                                             "metaName": "LayoutPos",
                                             "metaType": "string",
                                             "metaValue": "925 104"
+                                        },
+                                        {
+                                            "metaName": "io_ports",
+                                            "metadata": [
+                                                {
+                                                    "metaName": "reference_definitions"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "metaName": "zValue",
+                                            "metaType": "string",
+                                            "metaValue": "34.000000"
                                         }
                                     ]
                                 }
@@ -108,11 +122,11 @@
                             "metaValue": "Define {arc_type} From {file}"
                         }
                     ]
-                },                
+                },
                 {
                     "metaName": "ViewportRect",
                     "metaType": "string",
-                    "metaValue": "-70 -264.492 1301 1008.98"
+                    "metaValue": "-70 -466.177 1301 1436.35"
                 },
                 {
                     "metaName": "DisplayMode",
@@ -122,7 +136,12 @@
                 {
                     "metaName": "LayoutPos",
                     "metaType": "string",
-                    "metaValue": "-828.426 -347.996"
+                    "metaValue": "-65.5 -19"
+                },
+                {
+                    "metaName": "zValue",
+                    "metaType": "string",
+                    "metaValue": "38.000000"
                 }
             ],
             "ports": [
@@ -178,6 +197,24 @@
                     "portDirection": "input",
                     "portType": "BifrostUsd::UsdListPosition",
                     "portDefault": "UsdListPositionFrontOfPrependList"
+                },
+                {
+                    "portName": "anchor_path",
+                    "portDirection": "input",
+                    "portType": "string",
+                    "portDefault": "",
+                    "metadata": [
+                        {
+                            "metaName": "UIWidgetProp",
+                            "metaType": "string",
+                            "metaValue": "browserType=folder"
+                        },
+                        {
+                            "metaName": "UIWidget",
+                            "metaType": "string",
+                            "metaValue": "FileBrowserWidget"
+                        }
+                    ]
                 }
             ],
             "compoundNodes": [
@@ -194,6 +231,11 @@
                             "metaName": "LayoutPos",
                             "metaType": "string",
                             "metaValue": "620 104"
+                        },
+                        {
+                            "metaName": "zValue",
+                            "metaType": "string",
+                            "metaValue": "31.000000"
                         }
                     ]
                 },
@@ -210,6 +252,11 @@
                             "metaName": "LayoutPos",
                             "metaType": "string",
                             "metaValue": "315 10"
+                        },
+                        {
+                            "metaName": "zValue",
+                            "metaType": "string",
+                            "metaValue": "32.000000"
                         }
                     ]
                 }
@@ -246,6 +293,10 @@
                 {
                     "source": ".position",
                     "target": "define_usd_reference.position"
+                },
+                {
+                    "source": ".anchor_path",
+                    "target": "define_usd_reference.anchor_path"
                 }
             ],
             "values": [

--- a/src/nodedefs/usd_geom_nodedefs.h
+++ b/src/nodedefs/usd_geom_nodedefs.h
@@ -209,7 +209,7 @@ USD_NODEDEF_DECL
 bool rotate_prim(BifrostUsd::Stage& stage USDPORT_INOUT("out_stage"),
                  const Amino::String&       prim_path,
                  const Bifrost::Math::rotation_order& rotation_order,
-                 const Bifrost::Math::float3&         rotation,
+                 const Bifrost::Math::float3&         rotation AMINO_ANNOTATE("Amino::Port metadata=[{UiSoftMin, string, -180}, {UiSoftMax, string, 180}]"),
                  const bool                           enable_time,
                  const float                          frame) //
     USDNODE_DOC_ICON_X("rotate_prim",

--- a/src/nodedefs/usd_prim_nodedefs.cpp
+++ b/src/nodedefs/usd_prim_nodedefs.cpp
@@ -94,6 +94,18 @@ bool get_prim_metadata_impl(const BifrostUsd::Stage& stage,
     return false;
 }
 
+std::string get_part_after_anchor_path(const std::string& anchor_path,
+                                    const std::string& identifier) {
+    std::string resolved_identifier = identifier;
+    if (anchor_path.length() > 0 &&
+        identifier.length() > anchor_path.length()) {
+        if (identifier.find(anchor_path, 0) == 0) {
+            resolved_identifier = identifier.substr(anchor_path.length() + 1);
+        }
+    }
+    return resolved_identifier;
+}
+
 } // namespace
 
 bool USD::Prim::get_prim_at_path(Amino::Ptr<BifrostUsd::Stage>        stage,
@@ -333,7 +345,8 @@ bool USD::Prim::add_reference_prim(
     const Amino::String&                reference_prim_path,
     const double                        layer_offset,
     const double                        layer_scale,
-    const BifrostUsd::UsdListPosition reference_position) {
+    const BifrostUsd::UsdListPosition reference_position,
+    const Amino::String& anchor_path) {
     if (!stage) return false;
     try {
         auto pxr_prim = USDUtils::get_prim_or_throw(prim_path, stage);
@@ -348,6 +361,8 @@ bool USD::Prim::add_reference_prim(
                 GetUsdListPosition(reference_position));
         } else {
             std::string identifier = reference_layer->GetIdentifier().c_str();
+            identifier = get_part_after_anchor_path(anchor_path.c_str(), identifier);
+
             if (reference_prim_path.empty()) {
                 return pxr_prim.GetReferences().AddReference(
                     identifier, pxr::SdfLayerOffset(layer_offset, layer_scale),
@@ -443,7 +458,8 @@ bool USD::Prim::add_payload_prim(
     const Amino::String&                payload_prim_path,
     const double                        layer_offset,
     const double                        layer_scale,
-    const BifrostUsd::UsdListPosition payload_position) {
+    const BifrostUsd::UsdListPosition payload_position,
+    const Amino::String& anchor_path) {
     if (!stage) return false;
     try {
         auto pxr_prim = USDUtils::get_prim_or_throw(prim_path, stage);
@@ -458,6 +474,8 @@ bool USD::Prim::add_payload_prim(
                 GetUsdListPosition(payload_position));
         } else {
             std::string identifier = payload_layer->GetIdentifier().c_str();
+            identifier = get_part_after_anchor_path(anchor_path.c_str(), identifier);
+            
             if (payload_prim_path.empty()) {
                 return pxr_prim.GetPayloads().AddPayload(
                     identifier, pxr::SdfLayerOffset(layer_offset, layer_scale),

--- a/src/nodedefs/usd_prim_nodedefs.h
+++ b/src/nodedefs/usd_prim_nodedefs.h
@@ -236,6 +236,10 @@ bool remove_applied_schema(BifrostUsd::Stage& stage USDPORT_INOUT("out_stage"),
 /// \param [in] layer_offset The layer time offset.
 /// \param [in] layer_scale The layer offset scale factor.
 /// \param [in] reference_position The position in the reference list.
+/// \param [in] anchor_path The anchor path is the front part of the
+///             layer identifier that you don't want to include in the
+///             reference list. If an empty or invalid anchor path is provided,
+///             nothing from the layer identifier will be removed.
 /// \returns true if the reference was added successfully.
 USD_NODEDEF_DECL
 bool add_reference_prim(
@@ -245,7 +249,8 @@ bool add_reference_prim(
     const Amino::String&                reference_prim_path,
     const double layer_offset           AMINO_ANNOTATE("Amino::Port value=0.0"),
     const double layer_scale            AMINO_ANNOTATE("Amino::Port value=1.0"),
-    const BifrostUsd::UsdListPosition reference_position)
+    const BifrostUsd::UsdListPosition reference_position,
+    const Amino::String& anchor_path=Amino::String{})
     USDNODE_DOC_ICON_X("add_reference_prim",
                        "add_reference_prim",
                        "usd.svg",
@@ -314,7 +319,11 @@ bool remove_payload_prim(
 /// \param [in] layer_offset The layer time offset.
 /// \param [in] layer_scale The layer offset scale factor.
 /// \param [in] payload_position The position in the payload list.
-/// \returns true if the payload was added successfully.
+/// \param [in] anchor_path The anchor path is the front part of the
+///             layer identifier that you don't want to include in the
+///             reference list. If an empty or invalid anchor path is provided,
+///             nothing from the layer identifier will be removed.
+/// \returns true if the reference was added successfully.
 USD_NODEDEF_DECL
 bool add_payload_prim(
     BifrostUsd::Stage& stage          USDPORT_INOUT("out_stage"),
@@ -323,7 +332,8 @@ bool add_payload_prim(
     const Amino::String&                payload_prim_path,
     const double layer_offset           AMINO_ANNOTATE("Amino::Port value=0.0"),
     const double layer_scale            AMINO_ANNOTATE("Amino::Port value=1.0"),
-    const BifrostUsd::UsdListPosition payload_position)
+    const BifrostUsd::UsdListPosition payload_position,
+    const Amino::String& anchor_path=Amino::String{})
     USDNODE_DOC_ICON_X("add_payload_prim",
                        "add_payload_prim",
                        "usd.svg",

--- a/src/nodedefs/usd_stage_nodedefs.h
+++ b/src/nodedefs/usd_stage_nodedefs.h
@@ -88,7 +88,7 @@ void open_stage_from_layer(const BifrostUsd::Layer&                 root_layer,
 ///
 /// \param [out] stage The USD stage.
 USD_NODEDEF_DECL
-void open_stage_from_cache(const Amino::long_t              id,
+void open_stage_from_cache(const Amino::long_t              id AMINO_ANNOTATE("Amino::Port metadata=[{UiSoftMin, string, 0}]"),
                            const int                        layer_index
                                AMINO_ANNOTATE("Amino::Port value=-1"),
                            Amino::Ptr<BifrostUsd::Stage>&   stage)


### PR DESCRIPTION
# New Relative Reference feature
In _define_usd_reference_,  _add_reference_prim_ and _add_payload_prim_, you can now specify an anchor path. 
For example, if you reference a file "/shows/abc/assets/teapot.usd" and set the _anchor_path_ parameter to "/shows/abc/", Bifrost USD will write "assets/teapot.usd" in the USD layer.

# UI changes
- The _rotate_prim_ node uses a UI soft min/max of -180/180 for its _rotation_ parameter
- The _open_stage_from_cache_ uses a UI soft min of 0 for its _id_ parameter