### PR TITLE
Feature/bifrost 10105/add support for usd type name maya attribute

### DIFF
--- a/examples/maya_plugin/plug-ins/bifrostUSDExamples.py.in
+++ b/examples/maya_plugin/plug-ins/bifrostUSDExamples.py.in
@@ -73,9 +73,9 @@ def initializePlugin(plugin):
     maya_main_window_menu.create_usd_menu()
 
     # Register Ufe Observer
-    from bifrost_usd import prim_path_observer
+    from bifrost_usd import dag_path_observer
 
-    prim_path_observer.register()
+    dag_path_observer.register()
 
     from bifrost_usd.component_creator import material_library_observer
 

--- a/examples/maya_plugin/python/bifrost_usd/author_usd_graph.py
+++ b/examples/maya_plugin/python/bifrost_usd/author_usd_graph.py
@@ -282,7 +282,7 @@ def _add_maya_mesh_to_stage(
     info: GraphEditorSelection,
     add_to_stage_path: str,
     index: int,
-    mergeTransformAndShape: bool = True,
+    mergeTransformAndShape: Optional[bool] = True,
 ) -> None:
     ioNode = cmds.vnnCompound(
         info.dgContainerFullPath, info.currentCompound, addIONode=True
@@ -598,7 +598,7 @@ def to_prim_path(ufe_path: str) -> str:
 
     mayaPath = "|" + "|".join(ufe_path.split("|")[2:])
 
-    # Since we merge transfrom and shape on Bifrost side,
+    # Since we merge transform and shape on the Bifrost side,
     # remove last name of te path if it is a mesh
     if cmds.ls(mayaPath, type="mesh"):
         mayaPath = "|".join(mayaPath.split("|")[:-1])

--- a/examples/maya_plugin/python/bifrost_usd/author_usd_graph.py
+++ b/examples/maya_plugin/python/bifrost_usd/author_usd_graph.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 # *****************************************************************************
 # +
-from typing import Dict, List
+from typing import Dict, List, Optional
 from dataclasses import dataclass
 
 from maya import cmds
@@ -29,6 +29,8 @@ from bifrost_usd.constants import (
 )
 
 from bifrost_usd.graph_api import GraphAPI
+from bifrost_usd.maya_usd_custom_attributes import get_parent_dag_path
+from bifrost_usd.maya_usd_custom_attributes import get_all_prim_types
 
 
 def log(args):
@@ -216,7 +218,6 @@ def _get_maya_paths_from_selection() -> tuple[list, list]:
     for transform in transformList:
         paths: list = []
         _get_children(transform, paths)
-
         for item in paths:
             meshes = cmds.listRelatives(
                 item, type="mesh", noIntermediate=True, fullPath=True
@@ -281,7 +282,7 @@ def _add_maya_mesh_to_stage(
     info: GraphEditorSelection,
     add_to_stage_path: str,
     index: int,
-    mergeTransformAndShape=True,
+    mergeTransformAndShape: bool = True,
 ) -> None:
     ioNode = cmds.vnnCompound(
         info.dgContainerFullPath, info.currentCompound, addIONode=True
@@ -322,6 +323,12 @@ def _add_maya_mesh_to_stage(
     )
 
     graphAPI.set_param(defineHierarchy, ("path", primPath))
+
+    primTypesList = get_all_prim_types(get_parent_dag_path(mesh_path))
+    primTypesList.reverse()
+    primTypesStr = " ".join(primTypesList)
+    graphAPI.set_param(defineHierarchy, ("types", primTypesStr))
+
     graphAPI.set_param(defineHierarchy, ("parent_is_scope", "1" if parentPath else "0"))
 
     # TODO: Use graphAPI
@@ -372,6 +379,13 @@ def _add_maya_leaf_xform_to_stage(
         ),
     )
 
+    primTypesList = get_all_prim_types(xform_path)
+    primTypesList.reverse()
+    primTypesStr = " ".join(primTypesList)
+    graphAPI.set_param(defineHierarchy, ("types", primTypesStr))
+
+    graphAPI.set_param(defineHierarchy, ("parent_is_scope", "0"))
+
 
 def _add_maya_selection_to_stage(info: GraphEditorSelection, add_to_stage_path: str):
     meshSelection, xfoLeafSelection = _get_maya_paths_from_selection()
@@ -384,7 +398,7 @@ def _add_maya_selection_to_stage(info: GraphEditorSelection, add_to_stage_path: 
         _add_maya_leaf_xform_to_stage(xfoPath, info, add_to_stage_path, index)
 
 
-def add_maya_selection_to_stage(selection=None) -> bool:
+def add_maya_selection_to_stage(selection: Optional[GraphEditorSelection] = None) -> bool:
     if not selection:
         selection = get_graph_editor_selection()
 
@@ -673,4 +687,4 @@ def open_bifrost_graph_from_prim_selection() -> None:
 
 
 if __name__ == "__main__":
-    open_bifrost_usd_graph()
+    add_maya_selection_to_stage()

--- a/examples/maya_plugin/python/bifrost_usd/dag_path_observer.py
+++ b/examples/maya_plugin/python/bifrost_usd/dag_path_observer.py
@@ -36,53 +36,47 @@ def log(args):
         print(args)
 
 
-class PrimPathObserver(ufe.Observer):
+class DagPathObserver(ufe.Observer):
+    """Update a prim path when a DAG path is changed.
+    If there is no Bifrost USD graph in the scene, do nothing."""
+
     def __init__(self):
-        super(PrimPathObserver, self).__init__()
+        super(DagPathObserver, self).__init__()
 
     def __call__(self, notification):
         if not has_bifrost_usd_graph():
             return
 
-        changedPath = notification.changedPath()
+        ufeChangedPath = notification.changedPath()
 
         if isinstance(notification, ufe.ObjectReparent):
-            log(
-                f"ObjectReparent: {notification.changedPath()}, {notification.item().path()}"
-            )
+            log(f"ObjectReparent: {ufeChangedPath}, {notification.item().path()}")
             newPrimPath = str(notification.item().path())
             if is_supported_prim_type(newPrimPath):
                 reparent_nodes_path_parameter(
-                    to_prim_path(str(changedPath)), to_prim_path(newPrimPath))
+                    to_prim_path(str(ufeChangedPath)), to_prim_path(newPrimPath)
+                )
 
         if isinstance(notification, ufe.ObjectPathRemove):
-            log(
-                f"ObjectPathRemove: {notification.changedPath()}, {notification.item().path()}"
-            )
+            log(f"ObjectPathRemove: {ufeChangedPath}, {notification.item().path()}")
 
         if isinstance(notification, ufe.ObjectRename):
-            log(
-                f"ObjectRename: {notification.changedPath()}, {notification.item().path()}"
-            )
+            log(f"ObjectRename: {ufeChangedPath}, {notification.item().path()}")
             newPath = str(notification.item().path())
             if is_supported_prim_type(newPath):
                 rename_nodes_path_parameter(
-                    to_prim_path(str(changedPath)), to_prim_path(newPath)
+                    to_prim_path(str(ufeChangedPath)), to_prim_path(newPath)
                 )
 
         if isinstance(notification, ufe.ObjectPathAdd):
-            log(
-                f"ObjectPathAdd: {notification.changedPath()}, {notification.item().path()}"
-            )
+            log(f"ObjectPathAdd: {ufeChangedPath}, {notification.item().path()}")
 
         if isinstance(notification, ufe.ObjectAdd):
-            log(
-                f"ObjectAdd: {notification.changedPath()}, {notification.item().path()}"
-            )
+            log(f"ObjectAdd: {ufeChangedPath}, {notification.item().path()}")
 
         if isinstance(notification, ufe.ObjectDelete):
-            log(f"ObjectDelete: {notification.changedPath()}")
-            if primPath := to_prim_path(str(changedPath)):
+            log(f"ObjectDelete: {ufeChangedPath}")
+            if primPath := to_prim_path(str(ufeChangedPath)):
                 delete_node(
                     primPath,
                     node_type=kDefinePrimHierarchy,
@@ -91,7 +85,7 @@ class PrimPathObserver(ufe.Observer):
 
 def register():
     global OBSERVER
-    OBSERVER = PrimPathObserver()
+    OBSERVER = DagPathObserver()
     ufe.Scene.addObserver(OBSERVER)
 
 

--- a/examples/maya_plugin/python/bifrost_usd/maya_usd_custom_attributes.py
+++ b/examples/maya_plugin/python/bifrost_usd/maya_usd_custom_attributes.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 # *****************************************************************************
 # +
-from typing import Any
+from typing import Any, Optional
 from dataclasses import dataclass
 from maya import cmds
 
@@ -27,12 +27,12 @@ class MayaUSDAttribute:
     typeName: str
 
 
-def get_mayausd_attributes(dag_path: str) -> list[Any]:
-    attrNames = cmds.listAttr(dag_path, userDefined=True)
+def get_mayausd_attributes(dag_path: str) -> list[MayaUSDAttribute]:
+    result: list[MayaUSDAttribute] = []
+    attrNames: list[str] = cmds.listAttr(dag_path, userDefined=True)
     if attrNames is None:
-        return []
+        return result
 
-    result: list[Any] = []
     for name in attrNames:
         if name.startswith("USD_"):
             value = cmds.getAttr(f"{dag_path}.{name}")
@@ -45,7 +45,6 @@ def get_mayausd_attributes(dag_path: str) -> list[Any]:
                     typeName == "string" or typeName == "bool"
                 ), f"Maya USD attribute should be a string or a bool on {dag_path}"
                 result.append(MayaUSDAttribute(name, value, typeName))
-
     return result
 
 
@@ -66,7 +65,7 @@ def get_parent_dag_path(dag_path: str) -> str:
     return parent[0]
 
 
-def get_all_prim_types(dag_path: str, defaultType="Xform") -> list[str]:
+def get_all_prim_types(dag_path: str, defaultType: Optional[str] = "Xform") -> list[str]:
     """Gives all the USD prim types from a Maya hierarchy.
     The prim type is found from the 'USD_typeName' attribute on every DAG nodes of the hierarchy.
     If this attribute is not found, it uses the defaultType.

--- a/examples/maya_plugin/python/bifrost_usd/maya_usd_custom_attributes.py
+++ b/examples/maya_plugin/python/bifrost_usd/maya_usd_custom_attributes.py
@@ -1,0 +1,83 @@
+# -
+# *****************************************************************************
+# Copyright 2024 Autodesk, Inc.
+#
+# Licensed under the Apache License, Version 2.0(the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License                    at
+#
+# http: // www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on   an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# *****************************************************************************
+# +
+from typing import Any
+from dataclasses import dataclass
+from maya import cmds
+
+
+@dataclass
+class MayaUSDAttribute:
+    name: str
+    value: Any
+    typeName: str
+
+
+def get_mayausd_attributes(dag_path: str) -> list[Any]:
+    attrNames = cmds.listAttr(dag_path, userDefined=True)
+    if attrNames is None:
+        return []
+
+    result: list[Any] = []
+    for name in attrNames:
+        if name.startswith("USD_"):
+            value = cmds.getAttr(f"{dag_path}.{name}")
+            typeName = cmds.getAttr(f"{dag_path}.{name}", type=True)
+            if typeName:
+                if typeName == "string":
+                    if value is None:
+                        value = ""
+                assert (
+                    typeName == "string" or typeName == "bool"
+                ), f"Maya USD attribute should be a string or a bool on {dag_path}"
+                result.append(MayaUSDAttribute(name, value, typeName))
+
+    return result
+
+
+def get_prim_type_from_maya_usd_attrib(dag_path: str, defaultType="Xform") -> str:
+    primType = defaultType
+    for attrib in get_mayausd_attributes(dag_path):
+        if attrib.name == "USD_typeName":
+            primType = attrib.value
+            break
+
+    return primType
+
+
+def get_parent_dag_path(dag_path: str) -> str:
+    parent = cmds.listRelatives(dag_path, parent=True, fullPath=True)
+    if parent is None:
+        return ""
+    return parent[0]
+
+
+def get_all_prim_types(dag_path: str, defaultType="Xform") -> list[str]:
+    """Gives all the USD prim types from a Maya hierarchy.
+    The prim type is found from the 'USD_typeName' attribute on every DAG nodes of the hierarchy.
+    If this attribute is not found, it uses the defaultType.
+
+    :return: The USD type names in same order than the DAG hierarchy.
+    """
+    prim_types: list[str] = []
+
+    dagPath = dag_path
+    while dagPath:
+        prim_types.append(get_prim_type_from_maya_usd_attrib(dagPath))
+        dagPath = get_parent_dag_path(dagPath)
+
+    return prim_types


### PR DESCRIPTION
When importing a Maya Model in a Bifrost USD graph, if a Maya attribute named "USD_typeName" is present on the DAG node, it will be used to set the prim type in the imported selection.

(such USD_typeName attribute is used by the Maya USD exporter to create USD prim with types who don't exist in Maya, so we use the same attribute).

The second commit is not related to this ticket. Just a renaming to improve readability.